### PR TITLE
fix: corrigir alinhamento de cards, botões SpinBox e nível de log com… Parte 002 -2

### DIFF
--- a/gui/pages/brokers_page.py
+++ b/gui/pages/brokers_page.py
@@ -82,6 +82,7 @@ class BrokersPage(QWidget):
         scroll_widget = QWidget()
         scroll_widget.setStyleSheet(themes.scroll_widget_style())
         self.slaves_grid = QGridLayout(scroll_widget)
+        self.slaves_grid.setContentsMargins(0, 0, 0, 0)
         self.slaves_grid.setSpacing(12)
         self.slaves_grid.setAlignment(Qt.AlignLeft | Qt.AlignTop)
         scroll.setWidget(scroll_widget)

--- a/gui/pages/dashboard_page.py
+++ b/gui/pages/dashboard_page.py
@@ -68,6 +68,7 @@ class DashboardPage(QWidget):
         scroll_widget = QWidget()
         scroll_widget.setStyleSheet(themes.scroll_widget_style())
         self.slaves_grid = QGridLayout(scroll_widget)
+        self.slaves_grid.setContentsMargins(0, 0, 0, 0)
         self.slaves_grid.setSpacing(12)
         self.slaves_grid.setAlignment(Qt.AlignLeft | Qt.AlignTop)
         scroll.setWidget(scroll_widget)

--- a/gui/pages/settings_page.py
+++ b/gui/pages/settings_page.py
@@ -91,10 +91,10 @@ class SettingsPage(QWidget):
 
         row3 = QHBoxLayout()
         row3.addWidget(QLabel("Nivel de log:"))
-        self.log_level_edit = QLineEdit()
-        self.log_level_edit.setPlaceholderText("INFO, DEBUG, WARNING, ERROR")
-        self.log_level_edit.setMaximumWidth(200)
-        row3.addWidget(self.log_level_edit)
+        self.log_level_combo = QComboBox()
+        self.log_level_combo.addItems(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
+        self.log_level_combo.setMaximumWidth(200)
+        row3.addWidget(self.log_level_combo)
         row3.addStretch()
         app_layout.addLayout(row3)
 
@@ -119,9 +119,10 @@ class SettingsPage(QWidget):
         self.splash_check.setChecked(
             self.config.getboolean('General', 'show_splash', fallback=True)
         )
-        self.log_level_edit.setText(
-            self.config.get('General', 'log_level', fallback='INFO')
-        )
+        saved_log_level = self.config.get('General', 'log_level', fallback='INFO').upper()
+        idx_log = self.log_level_combo.findText(saved_log_level)
+        if idx_log >= 0:
+            self.log_level_combo.setCurrentIndex(idx_log)
         # Tema
         saved_theme = self.config.get('GUI', 'theme', fallback='Escuro')
         idx = self.theme_combo.findText(saved_theme)
@@ -136,7 +137,7 @@ class SettingsPage(QWidget):
             self.config.set('General', 'base_mt5_path', self.mt5_path_edit.text())
             self.config.set('General', 'monitor_interval', str(self.monitor_interval_spin.value()))
             self.config.set('General', 'show_splash', str(self.splash_check.isChecked()))
-            self.config.set('General', 'log_level', self.log_level_edit.text().upper())
+            self.config.set('General', 'log_level', self.log_level_combo.currentText())
 
             # Salvar e aplicar tema
             new_theme = self.theme_combo.currentText()

--- a/gui/themes.py
+++ b/gui/themes.py
@@ -389,6 +389,26 @@ QLineEdit, QSpinBox, QComboBox {{
     border-radius: 4px;
     padding: 6px;
 }}
+QSpinBox::up-button, QSpinBox::down-button {{
+    width: 20px;
+    border: 1px solid {c['border_hover']};
+}}
+QSpinBox::up-arrow {{
+    image: none;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 5px solid {c['text']};
+    width: 0px;
+    height: 0px;
+}}
+QSpinBox::down-arrow {{
+    image: none;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid {c['text']};
+    width: 0px;
+    height: 0px;
+}}
 QCheckBox {{
     color: {c['text']};
     font-size: 13px;
@@ -515,6 +535,26 @@ QLineEdit, QComboBox, QDoubleSpinBox {{
     border: 1px solid {c['border_hover']};
     border-radius: 4px;
     padding: 4px;
+}}
+QDoubleSpinBox::up-button, QDoubleSpinBox::down-button {{
+    width: 20px;
+    border: 1px solid {c['border_hover']};
+}}
+QDoubleSpinBox::up-arrow {{
+    image: none;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 5px solid {c['text']};
+    width: 0px;
+    height: 0px;
+}}
+QDoubleSpinBox::down-arrow {{
+    image: none;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid {c['text']};
+    width: 0px;
+    height: 0px;
 }}
 QPushButton {{
     color: {c['text']};


### PR DESCRIPTION
…o ComboBox

- Dashboard/Brokers: remover margens default do grid de slaves (contentsMargins=0)
- Themes: adicionar estilos explícitos para up/down buttons do QSpinBox e QDoubleSpinBox para resolver botão de incremento que não funcionava
- Settings: trocar campo de nível de log de QLineEdit para QComboBox com opções DEBUG, INFO, WARNING, ERROR, CRITICAL

https://claude.ai/code/session_01AAJg9tAt7GCSKmbek9MCFr