### PR TITLE
fix: setas dos SpinBox/ComboBox e largura fixa nos labels CPU/RAM

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -142,8 +142,10 @@ class MainWindow(QMainWindow):
         self.internet_label.setProperty("class", "header-status")
         self.cpu_label = QLabel("CPU: --%")
         self.cpu_label.setProperty("class", "header-status")
+        self.cpu_label.setFixedWidth(90)
         self.mem_label = QLabel("RAM: --%")
         self.mem_label.setProperty("class", "header-status")
+        self.mem_label.setFixedWidth(90)
 
         for lbl in (self.internet_label, self.cpu_label, self.mem_label):
             layout.addWidget(lbl)

--- a/gui/themes.py
+++ b/gui/themes.py
@@ -389,25 +389,39 @@ QLineEdit, QSpinBox, QComboBox {{
     border-radius: 4px;
     padding: 6px;
 }}
-QSpinBox::up-button, QSpinBox::down-button {{
+QSpinBox::up-button {{
+    subcontrol-origin: border;
+    subcontrol-position: top right;
     width: 20px;
-    border: 1px solid {c['border_hover']};
+    border-left: 1px solid {c['border_hover']};
+    border-bottom: 1px solid {c['border_hover']};
+    background-color: {c['input']};
+}}
+QSpinBox::up-button:hover {{
+    background-color: {c['border_hover']};
+}}
+QSpinBox::down-button {{
+    subcontrol-origin: border;
+    subcontrol-position: bottom right;
+    width: 20px;
+    border-left: 1px solid {c['border_hover']};
+    border-top: 1px solid {c['border_hover']};
+    background-color: {c['input']};
+}}
+QSpinBox::down-button:hover {{
+    background-color: {c['border_hover']};
 }}
 QSpinBox::up-arrow {{
-    image: none;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
+    width: 0px; height: 0px;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
     border-bottom: 5px solid {c['text']};
-    width: 0px;
-    height: 0px;
 }}
 QSpinBox::down-arrow {{
-    image: none;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
+    width: 0px; height: 0px;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
     border-top: 5px solid {c['text']};
-    width: 0px;
-    height: 0px;
 }}
 QCheckBox {{
     color: {c['text']};
@@ -536,25 +550,39 @@ QLineEdit, QComboBox, QDoubleSpinBox {{
     border-radius: 4px;
     padding: 4px;
 }}
-QDoubleSpinBox::up-button, QDoubleSpinBox::down-button {{
+QDoubleSpinBox::up-button {{
+    subcontrol-origin: border;
+    subcontrol-position: top right;
     width: 20px;
-    border: 1px solid {c['border_hover']};
+    border-left: 1px solid {c['border_hover']};
+    border-bottom: 1px solid {c['border_hover']};
+    background-color: {c['input']};
+}}
+QDoubleSpinBox::up-button:hover {{
+    background-color: {c['border_hover']};
+}}
+QDoubleSpinBox::down-button {{
+    subcontrol-origin: border;
+    subcontrol-position: bottom right;
+    width: 20px;
+    border-left: 1px solid {c['border_hover']};
+    border-top: 1px solid {c['border_hover']};
+    background-color: {c['input']};
+}}
+QDoubleSpinBox::down-button:hover {{
+    background-color: {c['border_hover']};
 }}
 QDoubleSpinBox::up-arrow {{
-    image: none;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
+    width: 0px; height: 0px;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
     border-bottom: 5px solid {c['text']};
-    width: 0px;
-    height: 0px;
 }}
 QDoubleSpinBox::down-arrow {{
-    image: none;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
+    width: 0px; height: 0px;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
     border-top: 5px solid {c['text']};
-    width: 0px;
-    height: 0px;
 }}
 QPushButton {{
     color: {c['text']};
@@ -632,7 +660,16 @@ QComboBox QAbstractItemView {{
     outline: none;
 }}
 QComboBox::drop-down {{
-    border: none;
+    subcontrol-origin: padding;
+    subcontrol-position: center right;
+    width: 20px;
+    border-left: 1px solid {c['border_hover']};
+}}
+QComboBox::down-arrow {{
+    width: 0px; height: 0px;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 6px solid {c['text']};
 }}
 QMessageBox {{
     background-color: {c['base']};


### PR DESCRIPTION
- SpinBox/DoubleSpinBox: estilizar up-button/down-button com subcontrol-position e up-arrow/down-arrow com CSS triangles para setas visíveis
- ComboBox: adicionar drop-down com seta para baixo no global_app_style (antes o border:none removia a seta completamente)
- Header: CPU e RAM com setFixedWidth(90) para evitar que a mudança de dígitos (ex: 7.5% → 18.6%) empurre o label Internet lateralmente

https://claude.ai/code/session_01AAJg9tAt7GCSKmbek9MCFr