### PR TITLE
fix: tratamento graceful de erros de validação de conta

### DIFF
--- a/core/copytrade_manager.py
+++ b/core/copytrade_manager.py
@@ -103,27 +103,11 @@ class CopyTradeManager(QObject):
 
     def _validate_account_modes(self):
         """
-        Valida que todas as contas configuradas são NETTING.
-        CopyTrade só suporta NETTING (não HEDGE) para simplificar lógica de replicação.
+        Log de confirmação: validação já foi feita em main.py.
+        Esta função existe apenas para documentação e possível re-validação.
         """
         brokers = self.broker_manager.get_brokers()
-
-        for broker_key, broker_data in brokers.items():
-            account_mode = self.broker_manager.get_account_mode(broker_key)
-
-            # Normalizar para comparação (case-insensitive)
-            mode_normalized = account_mode.lower()
-
-            if mode_normalized not in ("netting", "netting account"):
-                logger.error(f"❌ {broker_key}: modo '{account_mode}' não suportado")
-                logger.error(f"   CopyTrade requer contas em NETTING mode")
-                logger.error(f"   Configure a conta como NETTING em brokers.json")
-                raise ValueError(
-                    f"CopyTrade não suporta {account_mode}. "
-                    f"Configure {broker_key} como NETTING."
-                )
-
-        logger.info(f"✅ Validação: Todas as {len(brokers)} contas estão em NETTING mode")
+        logger.debug(f"✅ CopyTradeManager: {len(brokers)} contas validadas como NETTING")
 
     # ──────────────────────────────────────────────
     # Bloco 1.5 - Gerenciamento de Status de Slaves

--- a/main.py
+++ b/main.py
@@ -142,6 +142,31 @@ async def shutdown_cleanup():
     logger.info("shutdown_cleanup concluído.")
 
 
+def _validate_account_modes_gracefully(broker_manager) -> str:
+    """
+    Valida modos de conta gracefully (sem exception).
+    Retorna mensagem de erro se houver, ou None se tudo OK.
+    """
+    brokers = broker_manager.get_brokers()
+
+    for broker_key, broker_data in brokers.items():
+        account_mode = broker_manager.get_account_mode(broker_key)
+        mode_normalized = account_mode.lower()
+
+        if mode_normalized not in ("netting", "netting account"):
+            error_msg = (
+                f"❌ Conta {broker_key} em modo '{account_mode}'\n\n"
+                f"CopyTrade requer NETTING mode.\n\n"
+                f"Solução:\n"
+                f"1. Edite brokers.json\n"
+                f"2. Mude 'mode': '{account_mode}' para 'mode': 'Netting'\n"
+                f"3. Ou remova a conta se o broker não oferece Netting"
+            )
+            return error_msg
+
+    return None
+
+
 def sigint_handler(*args):
     if not shutdown_event.is_set():
         shutdown_event.set()
@@ -216,6 +241,15 @@ async def main_application_flow(config: ConfigManager):
     zmq_router_instance = ZmqRouter(None)
     broker_manager = BrokerManager(config, base_mt5_path, root_path, zmq_router_instance)
     zmq_router_instance.broker_manager = broker_manager
+
+    # Validar modos de conta ANTES de criar CopyTradeManager
+    account_mode_error = _validate_account_modes_gracefully(broker_manager)
+    if account_mode_error:
+        # Mostrar erro gracefully
+        from PySide6.QtWidgets import QMessageBox
+        QMessageBox.critical(None, "Erro de Configuração", account_mode_error)
+        logger.error(f"Aplicação encerrada: {account_mode_error}")
+        return
 
     copytrade_manager = CopyTradeManager(broker_manager, zmq_router_instance)
     copytrade_manager.start_heartbeat()


### PR DESCRIPTION
PROBLEMA: Validação de NETTING mode lançava ValueError no __init__, derrubando a aplicação com exception feia.

SOLUÇÃO:
1. Validação movida para main.py ANTES de criar CopyTradeManager
2. _validate_account_modes_gracefully() retorna string de erro (ou None)
3. Se há erro: mostra QMessageBox.critical() e retorna gracefully
4. CopyTradeManager._validate_account_modes() agora é apenas log

Resultado: Se conta estiver em Hedge, usuário vê caixa de diálogo clara explicando o problema e como resolver, ao invés de exception.

https://claude.ai/code/session_01BLQAjQqd3J9HpguwUZymye