### PR TITLE
feat: grace period + max retries no process monitor para evitar crash… - 004 - 1

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -32,3 +32,11 @@ heartbeat_interval = 5
 max_price_deviation = 30
 ; Idade máxima de uma operação para retry (em segundos)
 max_retry_age = 5
+
+[ProcessMonitor]
+; Grace period antes de reiniciar MT5 (segundos) - cobre updates automáticos
+grace_period = 60
+; Máximo de tentativas de restart antes de desistir
+max_retries = 3
+; Backoff base entre retries (segundos) - dobra a cada tentativa: 5, 10, 20
+backoff_base = 5

--- a/core/mt5_process_monitor.py
+++ b/core/mt5_process_monitor.py
@@ -13,21 +13,30 @@ logger = logging.getLogger(__name__)
 
 
 class MT5ProcessMonitor:
-    def __init__(self, broker_manager, event_loop, check_interval=10):
-        """
-        Inicializa o monitor de processos MT5.
-
-        Args:
-            broker_manager (BrokerManager): Instância do BrokerManager.
-            event_loop (asyncio.AbstractEventLoop): Loop de eventos asyncio principal.
-            check_interval (int): Intervalo de verificação em segundos.
-        """
+    def __init__(self, broker_manager, event_loop, config_manager=None, check_interval=10):
         self.broker_manager = broker_manager
         self.event_loop = event_loop
         self.check_interval = check_interval
         self.running = False
         self.monitor_thread = None
-        logger.info("MT5ProcessMonitor inicializado.")
+
+        # Grace period e retry config (do config.ini ou defaults)
+        if config_manager:
+            cfg = config_manager.config if hasattr(config_manager, 'config') else config_manager
+            self.grace_period = cfg.getint('ProcessMonitor', 'grace_period', fallback=60)
+            self.max_retries = cfg.getint('ProcessMonitor', 'max_retries', fallback=3)
+            self.backoff_base = cfg.getint('ProcessMonitor', 'backoff_base', fallback=5)
+        else:
+            self.grace_period = 60
+            self.max_retries = 3
+            self.backoff_base = 5
+
+        # Estado por broker: rastreia grace period e retries
+        self._death_detected_at = {}   # key -> timestamp da primeira detecção de morte
+        self._retry_count = {}         # key -> número de restarts tentados
+        self._failed_brokers = set()   # brokers que esgotaram retries
+
+        logger.info(f"MT5ProcessMonitor inicializado (grace={self.grace_period}s, max_retries={self.max_retries}, backoff_base={self.backoff_base}s).")
 
     def start(self):
         if not self.monitor_thread or not self.monitor_thread.is_alive():
@@ -57,21 +66,85 @@ class MT5ProcessMonitor:
                 logger.error(f"Erro no loop de monitoramento: {e}")
             time.sleep(self.check_interval)
 
+    def on_broker_registered(self, key):
+        """Chamado quando EA envia REGISTER - cancela grace period/retry."""
+        if key in self._death_detected_at:
+            elapsed = time.time() - self._death_detected_at[key]
+            logger.info(f"MT5 {key} reconectou após {elapsed:.0f}s (provável update). Cancelando restart.")
+            del self._death_detected_at[key]
+        self._retry_count.pop(key, None)
+        self._failed_brokers.discard(key)
+
     def check_and_restart_processes(self):
         for key in self.broker_manager.get_brokers():
             if not self.broker_manager.is_connected(key):
                 continue
 
+            if key in self._failed_brokers:
+                continue
+
             process = self.broker_manager.mt5_processes.get(key)
+            process_dead = False
+
             if process:
                 if process.poll() is not None:
-                    logger.warning(f"MT5 para {key} terminou (exit={process.poll()}). Reiniciando...")
-                    del self.broker_manager.mt5_processes[key]
-                    self.broker_manager.connected_brokers[key] = False
-                    self.restart_mt5_instance(key)
+                    process_dead = True
             else:
-                logger.warning(f"MT5 para {key} não encontrado mas marcado conectado. Reiniciando...")
-                self.restart_mt5_instance(key)
+                process_dead = True
+
+            if not process_dead:
+                # Processo vivo - limpar estado se tinha morte detectada
+                if key in self._death_detected_at:
+                    logger.info(f"MT5 {key} voltou sozinho. Cancelando grace period.")
+                    del self._death_detected_at[key]
+                    self._retry_count.pop(key, None)
+                continue
+
+            # --- Processo morto ---
+            now = time.time()
+
+            # Primeira detecção de morte? Iniciar grace period
+            if key not in self._death_detected_at:
+                exit_code = process.poll() if process else "N/A"
+                logger.warning(f"MT5 {key} morreu (exit={exit_code}). Aguardando grace period de {self.grace_period}s (possível update)...")
+                self._death_detected_at[key] = now
+                if process and key in self.broker_manager.mt5_processes:
+                    del self.broker_manager.mt5_processes[key]
+                self.broker_manager.connected_brokers[key] = False
+                continue
+
+            # Ainda dentro do grace period? Esperar
+            elapsed = now - self._death_detected_at[key]
+            if elapsed < self.grace_period:
+                remaining = self.grace_period - elapsed
+                logger.debug(f"MT5 {key} — grace period: {remaining:.0f}s restantes.")
+                continue
+
+            # Grace period expirou — tentar restart
+            retries = self._retry_count.get(key, 0)
+            if retries >= self.max_retries:
+                logger.error(f"MT5 {key} — esgotou {self.max_retries} tentativas de restart. Desistindo.")
+                self._failed_brokers.add(key)
+                self._death_detected_at.pop(key, None)
+                self.broker_manager.connected_brokers[key] = False
+                continue
+
+            # Backoff exponencial entre retries
+            if retries > 0:
+                backoff = self.backoff_base * (2 ** (retries - 1))
+                time_since_death = elapsed - self.grace_period
+                if time_since_death < backoff * retries:
+                    logger.debug(f"MT5 {key} — backoff: aguardando antes do retry #{retries + 1}.")
+                    continue
+
+            logger.warning(f"MT5 {key} — tentativa de restart {retries + 1}/{self.max_retries}...")
+            success = self.restart_mt5_instance(key)
+            self._retry_count[key] = retries + 1
+
+            if success:
+                logger.info(f"MT5 {key} — restart enviado (tentativa {retries + 1}). Aguardando REGISTER do EA...")
+            else:
+                logger.error(f"MT5 {key} — falha no restart (tentativa {retries + 1}/{self.max_retries}).")
 
     def restart_mt5_instance(self, key):
         instance_path = os.path.join(self.broker_manager.instances_dir, key, "terminal64.exe")

--- a/core/zmq_message_handler.py
+++ b/core/zmq_message_handler.py
@@ -81,6 +81,10 @@ class ZmqMessageHandler(QObject):
                 self.ping_button_state_changed.emit(True)
                 self.heartbeat_active[broker_key] = True
 
+                # Notificar process monitor para cancelar grace period/retry
+                if hasattr(self, 'mt5_monitor') and self.mt5_monitor:
+                    self.mt5_monitor.on_broker_registered(broker_key)
+
                 # Configurar intervalo de heartbeat no EA
                 if self.zmq_router:
                     asyncio.create_task(

--- a/main.py
+++ b/main.py
@@ -225,6 +225,7 @@ async def main_application_flow(config: ConfigManager):
     mt5_monitor = MT5ProcessMonitor(
         broker_manager,
         event_loop=asyncio.get_event_loop(),
+        config_manager=config,
         check_interval=config.getint('General', 'monitor_interval', fallback=10)
     )
     mt5_monitor.start()
@@ -239,8 +240,9 @@ async def main_application_flow(config: ConfigManager):
     main_window.show()
     logger.info("MainWindow exibida.")
 
-    # Wire copytrade_manager into message handler
+    # Wire copytrade_manager and process monitor into message handler
     main_window.zmq_message_handler.set_copytrade_manager(copytrade_manager)
+    main_window.zmq_message_handler.mt5_monitor = mt5_monitor
 
     # Detectar account modes em background (após MT5 instâncias iniciarem)
     asyncio.create_task(copytrade_manager.detect_all_account_modes())


### PR DESCRIPTION
… loop

- Grace period configurável (default 60s) antes de reiniciar MT5
- Cobre cenário de update automático do MT5 (terminal fecha e volta sozinho)
- Max retries (default 3) com backoff exponencial para crash real
- Brokers que esgotam retries são marcados como FAILED
- EA REGISTER cancela grace period (confirma que MT5 voltou)
- Tudo configurável via [ProcessMonitor] no config.ini

https://claude.ai/code/session_01YVrdNDmLnRdrsiaL21uoi2