### PR TITLE
fix: reescrever process monitor - restart imediato + proteção crash loop - Parte 004 -2

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -34,9 +34,9 @@ max_price_deviation = 30
 max_retry_age = 5
 
 [ProcessMonitor]
-; Grace period antes de reiniciar MT5 (segundos) - cobre updates automáticos
-grace_period = 60
 ; Máximo de tentativas de restart antes de desistir
 max_retries = 3
 ; Backoff base entre retries (segundos) - dobra a cada tentativa: 5, 10, 20
 backoff_base = 5
+; Janela de crash (segundos) - se MT5 morrer dentro desse tempo após restart, conta como crash loop
+crash_window = 30

--- a/core/mt5_process_monitor.py
+++ b/core/mt5_process_monitor.py
@@ -1,6 +1,7 @@
 # EPCopyFlow 2.0 - Versão 0.0.1 - Claude Code Parte 000
 # core/mt5_process_monitor.py
 # Monitor de processos MT5 - watchdog que reinicia instâncias que caírem.
+# Proteção contra crash loop: max retries + backoff exponencial.
 
 import os
 import subprocess
@@ -20,23 +21,24 @@ class MT5ProcessMonitor:
         self.running = False
         self.monitor_thread = None
 
-        # Grace period e retry config (do config.ini ou defaults)
+        # Retry config (do config.ini ou defaults)
         if config_manager:
             cfg = config_manager.config if hasattr(config_manager, 'config') else config_manager
-            self.grace_period = cfg.getint('ProcessMonitor', 'grace_period', fallback=60)
             self.max_retries = cfg.getint('ProcessMonitor', 'max_retries', fallback=3)
             self.backoff_base = cfg.getint('ProcessMonitor', 'backoff_base', fallback=5)
+            self.crash_window = cfg.getint('ProcessMonitor', 'crash_window', fallback=30)
         else:
-            self.grace_period = 60
             self.max_retries = 3
             self.backoff_base = 5
+            self.crash_window = 30
 
-        # Estado por broker: rastreia grace period e retries
-        self._death_detected_at = {}   # key -> timestamp da primeira detecção de morte
-        self._retry_count = {}         # key -> número de restarts tentados
+        # Estado por broker
+        self._retry_count = {}         # key -> número de restarts consecutivos
+        self._last_restart_at = {}     # key -> timestamp do último restart
+        self._last_alive_at = {}       # key -> timestamp da última vez visto vivo
         self._failed_brokers = set()   # brokers que esgotaram retries
 
-        logger.info(f"MT5ProcessMonitor inicializado (grace={self.grace_period}s, max_retries={self.max_retries}, backoff_base={self.backoff_base}s).")
+        logger.info(f"MT5ProcessMonitor inicializado (max_retries={self.max_retries}, backoff_base={self.backoff_base}s, crash_window={self.crash_window}s).")
 
     def start(self):
         if not self.monitor_thread or not self.monitor_thread.is_alive():
@@ -67,15 +69,17 @@ class MT5ProcessMonitor:
             time.sleep(self.check_interval)
 
     def on_broker_registered(self, key):
-        """Chamado quando EA envia REGISTER - cancela grace period/retry."""
-        if key in self._death_detected_at:
-            elapsed = time.time() - self._death_detected_at[key]
-            logger.info(f"MT5 {key} reconectou após {elapsed:.0f}s (provável update). Cancelando restart.")
-            del self._death_detected_at[key]
+        """Chamado quando EA envia REGISTER — MT5 voltou com sucesso."""
+        retries = self._retry_count.get(key, 0)
+        if retries > 0:
+            logger.info(f"MT5 {key} reconectou após {retries} restart(s). Resetando contadores.")
         self._retry_count.pop(key, None)
+        self._last_restart_at.pop(key, None)
         self._failed_brokers.discard(key)
 
     def check_and_restart_processes(self):
+        now = time.time()
+
         for key in self.broker_manager.get_brokers():
             if not self.broker_manager.is_connected(key):
                 continue
@@ -84,67 +88,68 @@ class MT5ProcessMonitor:
                 continue
 
             process = self.broker_manager.mt5_processes.get(key)
-            process_dead = False
-
-            if process:
-                if process.poll() is not None:
-                    process_dead = True
-            else:
-                process_dead = True
+            process_dead = (process is None) or (process.poll() is not None)
 
             if not process_dead:
-                # Processo vivo - limpar estado se tinha morte detectada
-                if key in self._death_detected_at:
-                    logger.info(f"MT5 {key} voltou sozinho. Cancelando grace period.")
-                    del self._death_detected_at[key]
-                    self._retry_count.pop(key, None)
+                # Processo vivo — registrar timestamp
+                self._last_alive_at[key] = now
                 continue
 
             # --- Processo morto ---
-            now = time.time()
 
-            # Primeira detecção de morte? Iniciar grace period
-            if key not in self._death_detected_at:
-                exit_code = process.poll() if process else "N/A"
-                logger.warning(f"MT5 {key} morreu (exit={exit_code}). Aguardando grace period de {self.grace_period}s (possível update)...")
-                self._death_detected_at[key] = now
-                if process and key in self.broker_manager.mt5_processes:
-                    del self.broker_manager.mt5_processes[key]
+            # Limpar processo morto do broker_manager
+            if process and key in self.broker_manager.mt5_processes:
+                exit_code = process.poll()
+                del self.broker_manager.mt5_processes[key]
                 self.broker_manager.connected_brokers[key] = False
-                continue
+            else:
+                exit_code = "N/A"
+                self.broker_manager.connected_brokers[key] = False
 
-            # Ainda dentro do grace period? Esperar
-            elapsed = now - self._death_detected_at[key]
-            if elapsed < self.grace_period:
-                remaining = self.grace_period - elapsed
-                logger.debug(f"MT5 {key} — grace period: {remaining:.0f}s restantes.")
-                continue
+            # Detectar crash loop: se morreu rápido demais após último restart
+            last_restart = self._last_restart_at.get(key)
+            if last_restart and (now - last_restart) < self.crash_window:
+                # Morreu dentro da janela de crash — incrementar retry
+                retries = self._retry_count.get(key, 0)
+                self._retry_count[key] = retries + 1
+            elif last_restart is None and key in self._retry_count:
+                # Já tem retries contados (continuação)
+                pass
+            else:
+                # Primeira morte ou morreu após funcionar normalmente — reset retries
+                self._retry_count[key] = 0
 
-            # Grace period expirou — tentar restart
             retries = self._retry_count.get(key, 0)
+
+            # Esgotou tentativas?
             if retries >= self.max_retries:
-                logger.error(f"MT5 {key} — esgotou {self.max_retries} tentativas de restart. Desistindo.")
+                logger.error(f"MT5 {key} — esgotou {self.max_retries} tentativas de restart (crash loop detectado). Desistindo.")
                 self._failed_brokers.add(key)
-                self._death_detected_at.pop(key, None)
-                self.broker_manager.connected_brokers[key] = False
+                self._retry_count.pop(key, None)
+                self._last_restart_at.pop(key, None)
                 continue
 
-            # Backoff exponencial entre retries
+            # Calcular backoff se não é primeira tentativa
             if retries > 0:
-                backoff = self.backoff_base * (2 ** (retries - 1))
-                time_since_death = elapsed - self.grace_period
-                if time_since_death < backoff * retries:
-                    logger.debug(f"MT5 {key} — backoff: aguardando antes do retry #{retries + 1}.")
-                    continue
+                backoff = self.backoff_base * (2 ** (retries - 1))  # 5, 10, 20...
+                if last_restart and (now - last_restart) < backoff:
+                    remaining = backoff - (now - last_restart)
+                    logger.debug(f"MT5 {key} — backoff: {remaining:.0f}s antes do retry #{retries + 1}.")
+                    # Re-adicionar processo como None para não perder o tracking
+                    return
+                logger.warning(f"MT5 {key} morreu (exit={exit_code}). Retry {retries + 1}/{self.max_retries} (backoff={backoff}s)...")
+            else:
+                logger.warning(f"MT5 {key} morreu (exit={exit_code}). Reiniciando imediatamente...")
 
-            logger.warning(f"MT5 {key} — tentativa de restart {retries + 1}/{self.max_retries}...")
+            # Reiniciar
             success = self.restart_mt5_instance(key)
-            self._retry_count[key] = retries + 1
+            self._last_restart_at[key] = time.time()
 
             if success:
-                logger.info(f"MT5 {key} — restart enviado (tentativa {retries + 1}). Aguardando REGISTER do EA...")
+                logger.info(f"MT5 {key} — restart enviado (tentativa {retries + 1}/{self.max_retries}).")
             else:
                 logger.error(f"MT5 {key} — falha no restart (tentativa {retries + 1}/{self.max_retries}).")
+                self._retry_count[key] = retries + 1
 
     def restart_mt5_instance(self, key):
         instance_path = os.path.join(self.broker_manager.instances_dir, key, "terminal64.exe")


### PR DESCRIPTION
- MT5 morreu → reinicia IMEDIATAMENTE (sem grace period)
- Se morrer de novo em <30s (crash_window) → conta como crash loop
- Crash loop: backoff exponencial (5s, 10s, 20s) + max 3 retries
- Se MT5 ficou vivo >30s antes de morrer → reset contadores (morte normal)
- EA REGISTER reseta contadores (confirma que voltou)
- Removido grace_period, adicionado crash_window no config.ini

https://claude.ai/code/session_01YVrdNDmLnRdrsiaL21uoi2