### PR TITLE
P2: Magic number + alien trade detection via DEAL_MAGIC - Parte 005 - 1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -43,11 +43,11 @@
   - Bug do MQL5: retcode=10009 (DONE) mas método retorna false
   - Fix: EA agora verifica `trade.ResultRetcode()` em vez do return value
 
-- [ ] **ALIEN OPERATIONS NÃO DETECTADAS (P2)** — Ordem aberta manualmente no Slave não é detectada
-  - Python deveria detectar (não tem ticket no open_positions) e pausar CopyTrade
-  - Causa: heartbeat é enviado pelo EA mas Python não processa para detecção
-  - Falta: implementação de `_detect_alien_operations()` que comparar posições Slave vs BD
-  - **PRÓXIMO PASSO**
+- [x] **ALIEN OPERATIONS DETECTADAS (P2)** — Detecção via magic number no EA ✅ FIXADO
+  - EA recebe magic number do Python (SET_MAGIC_NUMBER) e seta no CTrade
+  - OnTradeTransaction: DEAL_MAGIC != nosso magic → envia ALIEN_TRADE event
+  - Python: handler loga warning + emite signal alien_trade_detected para UI
+  - Abordagem mais robusta que heartbeat: detecta em tempo real, sem race conditions
 
 ## CopyTrade - Implementação em Andamento
 - [x] Fix JSON serialization bug (flattening nested JSONNode objects)
@@ -71,8 +71,8 @@
 - [x] Tracking de direction (BUY/SELL) para distinguir ADD vs REDUCE
 - [x] Callbacks diferenciados: _on_open, _on_close, _on_add, _on_partial_close
 - [x] Limpeza de código morto (heartbeat, reconcile, alien stubs, validate_account_modes)
-- [ ] **P2: Implementar _detect_alien_operations()** — comparar heartbeat Slave vs open_positions ← PRÓXIMO
-- [ ] **P2: Pausar CopyTrade automaticamente** quando alien detectado (com mensagem clara)
+- [x] **P2: Detecção de alien via magic number no EA** — DEAL_MAGIC check em OnTradeTransaction ✅
+- [ ] **P2: Pausar CopyTrade automaticamente** quando alien detectado (conectar signal à UI)
 - [ ] **P3: Auto-detecção HEDGE/NETTING** — adaptar fluxo conforme modo da conta
 - [ ] Retry com validação preço/tempo - max_price_deviation e max_retry_age
 - [ ] UI para visualizar status de slaves (ACTIVE/PAUSED com motivo da pausa)

--- a/config.ini
+++ b/config.ini
@@ -28,6 +28,9 @@ status_update_interval=60000
 require_netting_mode = true
 ; Intervalo do heartbeat de sincronização em segundos
 heartbeat_interval = 5
+; Magic number usado em todos os trades do CopyTrade (identifica trades do robô vs manuais)
+; Valor único. Se alterado com posições abertas, o rastreamento pode ser afetado.
+magic_number = 123456789
 ; Desvio máximo de preço para permitir retry (em pontos/pips)
 max_price_deviation = 30
 ; Idade máxima de uma operação para retry (em segundos)

--- a/core/zmq_message_handler.py
+++ b/core/zmq_message_handler.py
@@ -29,6 +29,7 @@ class ZmqMessageHandler(QObject):
     connection_status_received = Signal(dict)
     trade_event_received = Signal(dict)
     trade_response_received = Signal(dict)
+    alien_trade_detected = Signal(dict)
 
     # ──────────────────────────────────────────────
     # Bloco 1 - Inicialização
@@ -85,10 +86,13 @@ class ZmqMessageHandler(QObject):
                 if hasattr(self, 'mt5_monitor') and self.mt5_monitor:
                     self.mt5_monitor.on_broker_registered(broker_key)
 
-                # Configurar intervalo de heartbeat no EA
+                # Configurar EA: heartbeat interval + magic number
                 if self.zmq_router:
                     asyncio.create_task(
                         self.zmq_router.configure_heartbeat_interval(broker_key)
+                    )
+                    asyncio.create_task(
+                        self.zmq_router.configure_magic_number(broker_key)
                     )
 
         elif msg_type == "INTERNAL" and event == "CLIENT_UNREGISTERED":
@@ -176,7 +180,29 @@ class ZmqMessageHandler(QObject):
                 self.heartbeat_active[broker_key] = True
                 logger.debug(f"💓 Primeiro heartbeat de {broker_key} ({role})")
 
-            # TODO: Processar heartbeat com posições para detecção de alienígenas (P2)
+        elif msg_type == "STREAM" and event == "ALIEN_TRADE":
+            alien_data = {
+                "broker_key": identified_broker_key,
+                "deal": message.get("deal", 0),
+                "deal_magic": message.get("deal_magic", 0),
+                "expected_magic": message.get("expected_magic", 0),
+                "symbol": message.get("symbol", ""),
+                "volume": message.get("volume", 0),
+                "deal_type": message.get("deal_type", ""),
+                "timestamp_mql": message.get("timestamp_mql", 0),
+            }
+            logger.warning(
+                f"ALIEN TRADE em {identified_broker_key}: "
+                f"{alien_data['deal_type']} {alien_data['symbol']} "
+                f"{alien_data['volume']} lotes (magic={alien_data['deal_magic']}, "
+                f"esperado={alien_data['expected_magic']})"
+            )
+            self.log_message_received.emit(
+                f"ALIEN TRADE detectado em {identified_broker_key}: "
+                f"{alien_data['deal_type']} {alien_data['symbol']} "
+                f"{alien_data['volume']} lotes — operacao NAO originada pelo CopyTrade!"
+            )
+            self.alien_trade_detected.emit(alien_data)
 
         # ── RESPONSE events ──
         elif msg_type == "RESPONSE":

--- a/core/zmq_router.py
+++ b/core/zmq_router.py
@@ -138,6 +138,36 @@ class ZmqRouter:
         except Exception as e:
             logger.error(f"Erro ao configurar heartbeat em {broker_key}: {e}", exc_info=True)
 
+    async def configure_magic_number(self, broker_key: str):
+        """
+        Configura o magic number no EA.
+        Lê do config.ini e envia SET_MAGIC_NUMBER.
+        """
+        try:
+            import configparser
+            config = configparser.ConfigParser()
+            config.read("config.ini")
+
+            magic_number = int(config.get("CopyTrade", "magic_number", fallback="0"))
+            if magic_number <= 0:
+                logger.debug(f"Magic number não configurado, pulando para {broker_key}")
+                return
+
+            response = await self.send_command_to_broker(
+                broker_key,
+                "SET_MAGIC_NUMBER",
+                {"magic_number": magic_number},
+                f"set_magic_{broker_key}_{int(time.time())}"
+            )
+
+            if response.get("status") == "OK":
+                logger.info(f"Magic number configurado em {broker_key}: {magic_number}")
+            else:
+                logger.warning(f"Falha ao configurar magic number em {broker_key}: {response.get('error_message', '?')}")
+
+        except Exception as e:
+            logger.error(f"Erro ao configurar magic number em {broker_key}: {e}", exc_info=True)
+
     # ──────────────────────────────────────────────
     # Bloco 5 - Processamento de Mensagens
     # ──────────────────────────────────────────────

--- a/mt5_ea/ZmqTraderBridge.mq5
+++ b/mt5_ea/ZmqTraderBridge.mq5
@@ -48,6 +48,9 @@ bool g_initial_connection_status_sent = false;
 ulong g_heartbeat_interval_ms = 5000;  // Padrão: 5 segundos (será configurado pelo Python)
 ulong g_last_heartbeat_time = 0;       // Timestamp do último heartbeat enviado
 
+//--- Magic number para identificar trades do CopyTrade (configurado pelo Python)
+long g_magic_number = 0;               // 0 = não configurado (desabilita detecção de aliens)
+
 //+------------------------------------------------------------------+
 //| Função auxiliar para trim de string                              |
 //+------------------------------------------------------------------+
@@ -381,6 +384,40 @@ void HandleSetHeartbeatIntervalCommand(const string request_id, JSONNode &payloa
    SendJsonMessage(response, command_socket, "Command");
 
    PrintFormat("Intervalo de heartbeat configurado: %d ms", interval);
+}
+
+void HandleSetMagicNumberCommand(const string request_id, JSONNode &payload)
+{
+   JSONNode response;
+   response["type"] = "RESPONSE";
+   response["request_id"] = request_id;
+
+   JSONNode *magic_node = payload["magic_number"];
+   if(CheckPointer(magic_node) == POINTER_INVALID)
+   {
+      response["status"] = "ERROR";
+      response["error_message"] = "magic_number nao fornecido";
+      SendJsonMessage(response, command_socket, "Command");
+      return;
+   }
+
+   long magic = StringToInteger(magic_node.ToString());
+   if(magic <= 0)
+   {
+      response["status"] = "ERROR";
+      response["error_message"] = StringFormat("magic_number invalido: %lld", magic);
+      SendJsonMessage(response, command_socket, "Command");
+      return;
+   }
+
+   g_magic_number = magic;
+   trade.SetExpertMagicNumber((ulong)magic);
+
+   response["status"] = "OK";
+   response["magic_number"] = magic;
+   SendJsonMessage(response, command_socket, "Command");
+
+   PrintFormat("Magic number configurado: %lld (CTrade atualizado)", magic);
 }
 
 void HandleGetPositionsCommand(const string request_id)
@@ -1033,6 +1070,10 @@ void ProcessCommand(JSONNode &json_command)
    {
       HandleSetHeartbeatIntervalCommand(request_id, payload);
    }
+   else if(command == "SET_MAGIC_NUMBER")
+   {
+      HandleSetMagicNumberCommand(request_id, payload);
+   }
    else if(command == "POSITIONS" || command == "GET_POSITIONS")
    {
       HandleGetPositionsCommand(request_id);
@@ -1184,5 +1225,41 @@ void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest 
    if(!SendJsonMessage(stream_msg, event_socket, "Event"))
    {
       Print("ERROR: Falha ao enviar TRADE_EVENT via EventSocket");
+   }
+
+   // ── Detecção de operação alienígena (apenas SLAVE, apenas trades com sucesso) ──
+   if(g_magic_number > 0 && g_role == "SLAVE" && result.retcode == TRADE_RETCODE_DONE
+      && result.deal > 0 && request.action == TRADE_ACTION_DEAL)
+   {
+      if(HistoryDealSelect(result.deal))
+      {
+         long deal_magic = HistoryDealGetInteger(result.deal, DEAL_MAGIC);
+         if(deal_magic != g_magic_number)
+         {
+            // Trade não veio do nosso EA — operação alienígena
+            string deal_symbol = HistoryDealGetString(result.deal, DEAL_SYMBOL);
+            double deal_volume = HistoryDealGetDouble(result.deal, DEAL_VOLUME);
+            long deal_type = HistoryDealGetInteger(result.deal, DEAL_TYPE);
+            string type_str = (deal_type == DEAL_TYPE_BUY) ? "BUY" : "SELL";
+
+            PrintFormat("ALIEN TRADE detectado! magic=%lld (esperado=%lld), symbol=%s, %s %.2f lotes",
+                        deal_magic, g_magic_number, deal_symbol, type_str, deal_volume);
+
+            JSONNode alien_msg;
+            alien_msg["type"] = "STREAM";
+            alien_msg["event"] = "ALIEN_TRADE";
+            alien_msg["timestamp_mql"] = (long)TimeCurrent();
+            alien_msg["role"] = g_role;
+            alien_msg["deal"] = (long)result.deal;
+            alien_msg["deal_magic"] = deal_magic;
+            alien_msg["expected_magic"] = g_magic_number;
+            alien_msg["symbol"] = deal_symbol;
+            alien_msg["volume"] = deal_volume;
+            alien_msg["deal_type"] = type_str;
+
+            if(!SendJsonMessage(alien_msg, event_socket, "Event"))
+               Print("ERROR: Falha ao enviar ALIEN_TRADE via EventSocket");
+         }
+      }
    }
 }


### PR DESCRIPTION
- config.ini: magic_number=123456789 na seção [CopyTrade]
- EA: SET_MAGIC_NUMBER command → g_magic_number + trade.SetExpertMagicNumber()
- EA: OnTradeTransaction detecta DEAL_MAGIC != nosso magic → envia ALIEN_TRADE event
- Python: zmq_router.configure_magic_number() enviado no REGISTER de cada broker
- Python: zmq_message_handler processa ALIEN_TRADE → log warning + signal para UI
- Detecção em tempo real, sem race conditions (vs abordagem por heartbeat)

https://claude.ai/code/session_01TCnZwSt29JxQ3K7WQJVr6F