### PR TITLE
fix(tcp_router): avoid orphaned coroutine warning on shutdown - parte 007 -6

### DIFF
--- a/core/tcp_router.py
+++ b/core/tcp_router.py
@@ -269,15 +269,18 @@ class TcpRouter:
             if broker_key_msg:
                 self._clients[broker_key_msg] = broker_key
 
-        # Despachar ao main loop (onde vivem os signals Qt)
-        if self._message_handler and self._main_loop:
+        # Despachar ao main loop (onde vivem os signals Qt).
+        # Evita tentativa de dispatch durante shutdown: se não estamos mais rodando,
+        # o main loop pode já ter sido fechado e run_coroutine_threadsafe falha.
+        if self._message_handler and self._main_loop and self._running:
+            coro = self._dispatch_to_handler(broker_key, message_data)
             try:
-                asyncio.run_coroutine_threadsafe(
-                    self._dispatch_to_handler(broker_key, message_data),
-                    self._main_loop,
-                )
+                asyncio.run_coroutine_threadsafe(coro, self._main_loop)
             except RuntimeError as e:
-                logger.warning(f"Main loop indisponível ao dispatchar: {e}")
+                # Fecha explicitamente o coroutine para evitar o warning
+                # "coroutine was never awaited" quando cai aqui durante shutdown.
+                coro.close()
+                logger.debug(f"Main loop indisponível ao dispatchar (shutdown): {e}")
 
     async def _dispatch_to_handler(self, broker_key: str, message_data: dict):
         """Executado no main loop (Qt). Chama o message_handler."""


### PR DESCRIPTION
During shutdown, _stop_server closes the broker socket, which causes _read_loop (running in a worker thread) to hit EOF and fall into its finally block, where it dispatches a SYSTEM/UNREGISTER message via _process_message. By that point the Qt main loop may already have stopped, so run_coroutine_threadsafe raises RuntimeError — but the coroutine object had already been constructed inline as the call argument, so it was left orphaned and later flagged by the GC as "coroutine '_dispatch_to_handler' was never awaited".

Guard the dispatch on self._running so we stop trying once stop() has been called, bind the coroutine to a local, and explicitly coro.close() it in the RuntimeError branch so there's no dangling coroutine to collect. Log level for that branch goes to DEBUG since it's an expected shutdown-race path, not a problem.

https://claude.ai/code/session_01EnrRsD4nKYLeXBhBSTFGrG