### PR TITLE
fix(ea): reduce SocketRead timeout 100ms→1ms to unblock MT5 main thread

### DIFF
--- a/mt5_ea/ZmqTraderBridge.mq5
+++ b/mt5_ea/ZmqTraderBridge.mq5
@@ -300,7 +300,10 @@ void TcpPumpReads()
 
    uchar tmp[];
    ArrayResize(tmp, (int)available);
-   int read = SocketRead(g_socket, tmp, available, 100);
+   // Timeout 1ms: SocketIsReadable já confirmou que os bytes estão no buffer
+   // do kernel. Bloco de 100ms (anterior) bloqueava a thread principal do MT5
+   // e causava freeze visível ao tentar restaurar a janela do terminal.
+   int read = SocketRead(g_socket, tmp, available, 1);
    if(read <= 0)
    {
       // Possivelmente desconectado


### PR DESCRIPTION
SocketRead(socket, buf, available, 100) rodava na thread principal do MT5, podendo bloquear até 100ms quando Python enviava qualquer dado ao EA (SET_MAGIC_NUMBER no REGISTER, PONG, resposta de trade, etc).

Nesse janela de 100ms, o Windows enfileirava mensagens de janela (WM_SHOWWINDOW, WM_PAINT) sem resposta → usuário percebia freeze ao tentar restaurar a janela minimizada do terminal.

Timeout de 1ms é suficiente porque SocketIsReadable() confirma que os bytes já estão no buffer do kernel antes de chamarmos SocketRead — a entrega é praticamente instantânea. O frame assembler em TcpExtractAndProcessFrames lida corretamente com leituras parciais se o kernel demorar mais que 1ms (improvável, mas seguro).