### PR TITLE
refactor: rename zmq_message_handler → tcp_message_handler - parte 007

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -33,7 +33,7 @@ class ConfigManager:
                 'log_level': 'INFO', # Movido para General por conveniência ou manter em Logging
                  # Adicione outros padrões gerais se necessário
             }
-            self.config['ZMQ'] = {
+            self.config['TCP'] = {
                 'host': '127.0.0.1',
                 'port': '5555',
                 'heartbeat_interval_s': '5', # Intervalo de heartbeat do EA

--- a/core/tcp_message_handler.py
+++ b/core/tcp_message_handler.py
@@ -1,6 +1,6 @@
 # EPCopyFlow 2.0 - Versão 0.0.1 - Claude Code Parte 000
-# core/zmq_message_handler.py
-# Manipulador de mensagens ZMQ simplificado para copytrade.
+# core/tcp_message_handler.py
+# Manipulador de mensagens TCP simplificado para copytrade.
 # Removidos: signals de indicadores, OHLC, ticks, streams (não usados no copytrade).
 
 import logging
@@ -15,7 +15,7 @@ trade_allowed_states = {}
 connection_status_states = {}  # True = broker conectado ao servidor, False = desconectado
 
 
-class ZmqMessageHandler(QObject):
+class TcpMessageHandler(QObject):
     # Sinais mantidos (essenciais para copytrade)
     log_message_received = Signal(str)
     ping_button_state_changed = Signal(bool)
@@ -50,7 +50,7 @@ class ZmqMessageHandler(QObject):
     # Bloco 2 - Handler Principal
     # ──────────────────────────────────────────────
     @Slot(bytes, object)
-    async def handle_zmq_message(self, client_id_bytes: bytes, message: dict):
+    async def handle_tcp_message(self, client_id_bytes: bytes, message: dict):
         global trade_allowed_states, connection_status_states
 
         # Identifica broker
@@ -63,7 +63,7 @@ class ZmqMessageHandler(QObject):
         if not identified_broker_key:
             identified_broker_key = message.get("broker_key")
 
-        log_prefix = f"ZMQ RX [{identified_broker_key or client_id_hex}]:"
+        log_prefix = f"TCP RX [{identified_broker_key or client_id_hex}]:"
 
         # Log (exceto TICK e HEARTBEAT que são muito frequentes)
         event = message.get("event")

--- a/core/tcp_router.py
+++ b/core/tcp_router.py
@@ -6,7 +6,7 @@
 # Protocolo de framing:
 #   [4 bytes big-endian unsigned length][UTF-8 JSON payload]
 #
-# Substitui o antigo core/zmq_router.py (issue #47).
+# Substitui o antigo core/zmq_router.py (migrado para TCP nativo no issue #47).
 #
 # Transporte: socket bloqueante + threading puro (sem asyncio nas threads worker).
 # Isso evita problemas com IocpProactor do Windows em threads não-principais.
@@ -333,12 +333,12 @@ class TcpRouter:
                     "type": "INTERNAL",
                     "event": "CLIENT_UNREGISTERED",
                     "broker_key": message_data.get("broker_key"),
-                    "zmq_id_hex": broker_key,
+                    "tcp_id": broker_key,
                 }
-                await self._message_handler.handle_zmq_message(
+                await self._message_handler.handle_tcp_message(
                     broker_key.encode('utf-8'), notification)
             else:
-                await self._message_handler.handle_zmq_message(
+                await self._message_handler.handle_tcp_message(
                     broker_key.encode('utf-8'), message_data)
         except Exception as e:
             logger.exception(f"Erro ao despachar mensagem de {broker_key}: {e}")

--- a/gui/brokers_dialog.py
+++ b/gui/brokers_dialog.py
@@ -273,7 +273,7 @@ class BrokersDialog(QDialog):
         try:
             command_port, event_port = self.broker_manager.generate_ports()
         except Exception as e:
-            QMessageBox.critical(self, "Erro de portas", f"Erro ao gerar portas ZMQ: {e}")
+            QMessageBox.critical(self, "Erro de portas", f"Erro ao gerar portas TCP: {e}")
             return
 
         key = self.broker_manager.add_broker(

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -14,7 +14,7 @@ from PySide6.QtCore import Slot, Qt, Signal, QTimer
 from core.config_manager import ConfigManager
 from core.broker_manager import BrokerManager
 from core.tcp_router import TcpRouter
-from core.zmq_message_handler import ZmqMessageHandler
+from core.tcp_message_handler import TcpMessageHandler
 from internet_monitor import InternetMonitor
 from gui import themes
 
@@ -48,7 +48,7 @@ class MainWindow(QMainWindow):
         self.root_path = root_path
         self.mt5_monitor = mt5_monitor
         self.copytrade_manager = copytrade_manager
-        self.zmq_message_handler = ZmqMessageHandler(
+        self.tcp_message_handler = TcpMessageHandler(
             config, tcp_router, broker_manager=broker_manager,
             copytrade_manager=copytrade_manager
         )
@@ -113,12 +113,12 @@ class MainWindow(QMainWindow):
         # Create pages
         self.dashboard_page = DashboardPage(
             self.broker_manager, self.copytrade_manager,
-            zmq_message_handler=self.zmq_message_handler
+            tcp_message_handler=self.tcp_message_handler
         )
         self.dashboard_page.set_broker_status(self.broker_status)
         self.brokers_page = BrokersPage(
             self.config, self.broker_manager, self.tcp_router, self.mt5_monitor,
-            zmq_message_handler=self.zmq_message_handler
+            tcp_message_handler=self.tcp_message_handler
         )
         self.brokers_page.set_broker_status(self.broker_status)
         self.history_page = HistoryPage(self.copytrade_manager)
@@ -246,14 +246,14 @@ class MainWindow(QMainWindow):
 
     # ── Signals ──
     def _connect_signals(self):
-        self.zmq_message_handler.log_message_received.connect(self.logs_page.append_log)
-        self.zmq_message_handler.log_message_received.connect(self._handle_zmq_messages)
-        self.zmq_message_handler.positions_received.connect(self.dashboard_page.update_positions)
-        self.zmq_message_handler.account_balance_received.connect(self.dashboard_page.update_balance)
+        self.tcp_message_handler.log_message_received.connect(self.logs_page.append_log)
+        self.tcp_message_handler.log_message_received.connect(self._handle_tcp_messages)
+        self.tcp_message_handler.positions_received.connect(self.dashboard_page.update_positions)
+        self.tcp_message_handler.account_balance_received.connect(self.dashboard_page.update_balance)
         # Atualizar indicadores quando status muda
-        self.zmq_message_handler.trade_allowed_update_received.connect(
+        self.tcp_message_handler.trade_allowed_update_received.connect(
             lambda _: self._update_all_indicators())
-        self.zmq_message_handler.connection_status_received.connect(
+        self.tcp_message_handler.connection_status_received.connect(
             lambda _: self._update_all_indicators())
         # Sincronizar dashboard quando broker conecta/desconecta via botão
         self.brokers_page.broker_status_changed.connect(self._on_broker_status_changed)
@@ -262,10 +262,10 @@ class MainWindow(QMainWindow):
             self.copytrade_manager.copy_trade_executed.connect(self.history_page.refresh)
             self.copytrade_manager.copy_trade_failed.connect(self.history_page.refresh)
         # Alien trade detection
-        self.zmq_message_handler.alien_trade_detected.connect(self._on_alien_trade_detected)
+        self.tcp_message_handler.alien_trade_detected.connect(self._on_alien_trade_detected)
 
     @Slot(str)
-    def _handle_zmq_messages(self, message: str):
+    def _handle_tcp_messages(self, message: str):
         status_changed = False
         for key in list(self.broker_status.keys()):
             if "REGISTER" in message and key in message and "UNREGISTER" not in message:
@@ -286,7 +286,7 @@ class MainWindow(QMainWindow):
         for key in list(self.broker_status.keys()):
             if not self.broker_manager.is_connected(key):
                 self.broker_status[key] = False
-                self.zmq_message_handler.clear_broker_status(key)
+                self.tcp_message_handler.clear_broker_status(key)
         self.dashboard_page.refresh_brokers()
         self.brokers_page.refresh_brokers()
 

--- a/gui/pages/brokers_page.py
+++ b/gui/pages/brokers_page.py
@@ -20,13 +20,13 @@ class BrokersPage(QWidget):
     broker_status_changed = Signal()
 
     def __init__(self, config, broker_manager, tcp_router, mt5_monitor,
-                 zmq_message_handler=None, parent=None):
+                 tcp_message_handler=None, parent=None):
         super().__init__(parent)
         self.config = config
         self.broker_manager = broker_manager
         self.tcp_router = tcp_router
         self.mt5_monitor = mt5_monitor
-        self.zmq_message_handler = zmq_message_handler
+        self.tcp_message_handler = tcp_message_handler
         self._broker_status = {}
         self.broker_cards = {}
         self.setStyleSheet(themes.brokers_page_style())
@@ -154,9 +154,9 @@ class BrokersPage(QWidget):
         """Update all 4 status indicators (MT5, EA, BRK, ALG) on every broker card."""
         trade_allowed = {}
         connection_status = {}
-        if self.zmq_message_handler:
-            trade_allowed = self.zmq_message_handler.get_trade_allowed_states()
-            connection_status = self.zmq_message_handler.get_connection_status_states()
+        if self.tcp_message_handler:
+            trade_allowed = self.tcp_message_handler.get_trade_allowed_states()
+            connection_status = self.tcp_message_handler.get_connection_status_states()
 
         for key, card in self.broker_cards.items():
             process = self.broker_manager.mt5_processes.get(key)

--- a/gui/pages/dashboard_page.py
+++ b/gui/pages/dashboard_page.py
@@ -16,11 +16,11 @@ logger = logging.getLogger(__name__)
 
 class DashboardPage(QWidget):
     def __init__(self, broker_manager, copytrade_manager=None,
-                 zmq_message_handler=None, parent=None):
+                 tcp_message_handler=None, parent=None):
         super().__init__(parent)
         self.broker_manager = broker_manager
         self.copytrade_manager = copytrade_manager
-        self.zmq_message_handler = zmq_message_handler
+        self.tcp_message_handler = tcp_message_handler
         self._broker_status = {}  # EA registered: {key: True/False}
         self.broker_cards = {}
         self.setStyleSheet(themes.dashboard_style())
@@ -166,9 +166,9 @@ class DashboardPage(QWidget):
         """Update all 4 status indicators (MT5, EA, BRK, ALG) on every broker card."""
         trade_allowed = {}
         connection_status = {}
-        if self.zmq_message_handler:
-            trade_allowed = self.zmq_message_handler.get_trade_allowed_states()
-            connection_status = self.zmq_message_handler.get_connection_status_states()
+        if self.tcp_message_handler:
+            trade_allowed = self.tcp_message_handler.get_trade_allowed_states()
+            connection_status = self.tcp_message_handler.get_connection_status_states()
 
         for key, card in self.broker_cards.items():
             # MT5: processo rodando?
@@ -180,7 +180,7 @@ class DashboardPage(QWidget):
                 card.update_status_indicators(mt5=None, ea=None, brk=None, alg=None)
                 continue
 
-            # EA registrado? (prova real de que ZMQ está funcionando)
+            # EA registrado? (prova real de que TCP está funcionando)
             ea_registered = self._broker_status.get(key, False)
 
             if not ea_registered:

--- a/gui/widgets/broker_card.py
+++ b/gui/widgets/broker_card.py
@@ -74,7 +74,7 @@ class BrokerCard(QFrame):
         row2.addWidget(self.status_label)
         layout.addLayout(row2)
 
-        # Row 3: Status indicators (MT5, BRK, ZMQ, EA, ALG)
+        # Row 3: Status indicators (MT5, EA, BRK, ALG)
         indicators_row = QHBoxLayout()
         indicators_row.setSpacing(12)
         self._indicators = {}

--- a/main.py
+++ b/main.py
@@ -240,13 +240,13 @@ async def main_application_flow(config: ConfigManager):
     logger.info("MainWindow exibida.")
 
     # Wire copytrade_manager and process monitor into message handler
-    main_window.zmq_message_handler.set_copytrade_manager(copytrade_manager)
-    main_window.zmq_message_handler.mt5_monitor = mt5_monitor
+    main_window.tcp_message_handler.set_copytrade_manager(copytrade_manager)
+    main_window.tcp_message_handler.mt5_monitor = mt5_monitor
 
     # Detectar account modes em background (após MT5 instâncias iniciarem)
     asyncio.create_task(copytrade_manager.detect_all_account_modes())
 
-    router_task = asyncio.create_task(tcp_router_instance.run(main_window.zmq_message_handler))
+    router_task = asyncio.create_task(tcp_router_instance.run(main_window.tcp_message_handler))
 
     logger.info("Setup concluído. Aguardando shutdown_event...")
 


### PR DESCRIPTION
- Arquivo renomeado: core/zmq_message_handler.py → core/tcp_message_handler.py
- Classe: ZmqMessageHandler → TcpMessageHandler
- Método: handle_zmq_message → handle_tcp_message
- Atributo: zmq_message_handler → tcp_message_handler em todos os módulos
- Log prefix: "ZMQ RX" → "TCP RX"
- config_manager: seção [ZMQ] → [TCP]
- Mensagens de erro e comentários atualizados para TCP

https://claude.ai/code/session_01EnrRsD4nKYLeXBhBSTFGrG