### PR TITLE
feat(copytrade): detect SL/TP closes and replicate SL/TP modification…

### DIFF
--- a/core/copytrade_manager.py
+++ b/core/copytrade_manager.py
@@ -101,13 +101,19 @@ class CopyTradeManager(QObject):
 
         self.db.commit()
 
-        # Migração: adicionar coluna direction se não existir
-        try:
-            self.db.execute("ALTER TABLE open_positions ADD COLUMN direction TEXT DEFAULT 'BUY'")
-            self.db.commit()
-            logger.info("Migração: coluna 'direction' adicionada a open_positions.")
-        except sqlite3.OperationalError:
-            pass  # Coluna já existe
+        # Migrações: adicionar colunas novas se não existirem
+        migrations = [
+            ("direction", "ALTER TABLE open_positions ADD COLUMN direction TEXT DEFAULT 'BUY'"),
+            ("sl", "ALTER TABLE open_positions ADD COLUMN sl REAL DEFAULT 0.0"),
+            ("tp", "ALTER TABLE open_positions ADD COLUMN tp REAL DEFAULT 0.0"),
+        ]
+        for col_name, sql in migrations:
+            try:
+                self.db.execute(sql)
+                self.db.commit()
+                logger.info(f"Migração: coluna '{col_name}' adicionada a open_positions.")
+            except sqlite3.OperationalError:
+                pass  # Coluna já existe
 
         logger.info("Banco de dados SQLite inicializado (3 tabelas).")
 
@@ -454,6 +460,67 @@ class CopyTradeManager(QObject):
         # Limpar lock se posição foi fechada (não há mais eventos esperados)
         if trade_action == "CLOSE":
             self._cleanup_position_lock(position_id)
+
+    async def handle_master_sltp_update(self, sltp_data: dict):
+        """Replica modificação de SL/TP do Master para todos os Slaves."""
+        position_id = sltp_data.get("position_id", 0)
+        symbol = sltp_data.get("symbol", "")
+        new_sl = sltp_data.get("sl", 0.0)
+        new_tp = sltp_data.get("tp", 0.0)
+
+        if not position_id:
+            logger.warning("SLTP_MODIFIED sem position_id, ignorando")
+            return
+
+        logger.info(f"SLTP_MODIFIED: pos_id={position_id}, symbol={symbol}, sl={new_sl}, tp={new_tp}")
+
+        self.db.execute(
+            "UPDATE open_positions SET sl = ?, tp = ? WHERE master_ticket = ? AND status = 'OPEN'",
+            (new_sl, new_tp, position_id)
+        )
+        self.db.commit()
+
+        slaves = self.broker_manager.get_connected_slave_brokers()
+        tasks = []
+        for slave_key in slaves:
+            if self.is_slave_paused(slave_key):
+                continue
+
+            pos_info = self._get_slave_position_info(position_id, slave_key)
+            if pos_info is None or pos_info["volume"] <= 0:
+                continue
+
+            slave_ticket = self._get_slave_ticket(position_id, slave_key)
+            if not slave_ticket:
+                logger.warning(f"  SLTP: slave {slave_key} sem ticket para pos_id={position_id}")
+                continue
+
+            tasks.append(self._replicate_sltp_to_slave(
+                slave_key, slave_ticket, new_sl, new_tp, position_id, symbol
+            ))
+
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    async def _replicate_sltp_to_slave(self, slave_key: str, slave_ticket: int,
+                                       sl: float, tp: float, position_id: int, symbol: str):
+        """Envia TRADE_POSITION_MODIFY para um slave."""
+        logger.info(f"  SLTP -> {slave_key}: ticket={slave_ticket}, sl={sl}, tp={tp}")
+
+        request_id = f"sltp_{slave_key}_{position_id}_{int(time.time())}"
+        response = await self.tcp_router.send_command_to_broker(
+            slave_key, "TRADE_POSITION_MODIFY",
+            {"ticket": slave_ticket, "sl": sl, "tp": tp},
+            request_id
+        )
+
+        if response.get("status") == "OK":
+            logger.info(f"  SLTP OK: {slave_key} pos_id={position_id}")
+            self.copy_trade_log.emit(f"SLTP [{slave_key}]: {symbol} sl={sl} tp={tp}")
+        else:
+            error = response.get("error_message", "unknown")
+            logger.error(f"  SLTP FALHOU: {slave_key} - {error}")
+            self.copy_trade_log.emit(f"SLTP ERRO [{slave_key}]: {symbol} - {error}")
 
     def _classify_trade_action(self, action: int, order_type: int, position_ticket: int,
                                position_volume_remaining=None) -> str:

--- a/core/tcp_message_handler.py
+++ b/core/tcp_message_handler.py
@@ -183,6 +183,32 @@ class TcpMessageHandler(QObject):
                 self.heartbeat_active[broker_key] = True
                 logger.debug(f"💓 Primeiro heartbeat de {broker_key} ({role})")
 
+        elif msg_type == "STREAM" and event == "SLTP_MODIFIED":
+            sltp_data = {
+                "broker_key": identified_broker_key,
+                "timestamp_mql": message.get("timestamp_mql", 0),
+                "position_id": message.get("position_id", 0),
+                "symbol": message.get("symbol", ""),
+                "sl": message.get("sl", 0.0),
+                "tp": message.get("tp", 0.0),
+                "old_sl": message.get("old_sl", 0.0),
+                "old_tp": message.get("old_tp", 0.0),
+                "volume": message.get("volume", 0.0),
+            }
+            logger.info(
+                f"SLTP_MODIFIED de {identified_broker_key} - pos_id={sltp_data['position_id']}, "
+                f"sl={sltp_data['old_sl']:.5f}->{sltp_data['sl']:.5f}, "
+                f"tp={sltp_data['old_tp']:.5f}->{sltp_data['tp']:.5f}"
+            )
+
+            if self.copytrade_manager and self.broker_manager:
+                if self.broker_manager.get_broker_role(identified_broker_key) == "master":
+                    t = asyncio.create_task(
+                        self.copytrade_manager.handle_master_sltp_update(sltp_data)
+                    )
+                    self._background_tasks.add(t)
+                    t.add_done_callback(self._background_tasks.discard)
+
         elif msg_type == "STREAM" and event == "ALIEN_TRADE":
             alien_data = {
                 "broker_key": identified_broker_key,

--- a/mt5_ea/ZmqTraderBridge.mq5
+++ b/mt5_ea/ZmqTraderBridge.mq5
@@ -54,6 +54,20 @@ bool g_initial_connection_status_sent = false;
 //--- (o sistema só detecta aliens após estar "pronto/conectado").
 long g_magic_number = 0;
 
+//--- Cache de posições para OnTrade() snapshot diff
+#define MAX_CACHED_POSITIONS 64
+struct CachedPosition {
+   long   position_id;
+   string symbol;
+   double volume;
+   double sl;
+   double tp;
+   long   pos_type;   // POSITION_TYPE_BUY=0, POSITION_TYPE_SELL=1
+   long   magic;
+};
+CachedPosition g_pos_cache[MAX_CACHED_POSITIONS];
+int g_pos_cache_size = 0;
+
 //--- REGISTER retry (OnInit pode enviar antes do Python conectar)
 bool g_register_sent = false;          // true quando REGISTER foi enviado com sucesso
 int  g_register_retries = 0;           // Contador de tentativas
@@ -1222,7 +1236,11 @@ int OnInit()
 
    g_last_trade_allowed = (bool)TerminalInfoInteger(TERMINAL_TRADE_ALLOWED);
    g_last_terminal_connected = (bool)TerminalInfoInteger(TERMINAL_CONNECTED);
-   PrintFormat("EPCopyFlow EA: Inicializado. Role=%s, BrokerKey=%s", g_role, g_brokerKey);
+
+   RefreshPositionCache();
+
+   PrintFormat("EPCopyFlow EA: Inicializado. Role=%s, BrokerKey=%s, cached_positions=%d",
+               g_role, g_brokerKey, g_pos_cache_size);
    return(INIT_SUCCEEDED);
 }
 
@@ -1452,6 +1470,159 @@ void ProcessCommand(JSONNode &json_command)
 }
 
 //+------------------------------------------------------------------+
+//| Bloco 4b - OnTrade() snapshot diff (MASTER only)                 |
+//| Detecta fechamentos por SL/TP/SO e modificações de SL/TP.        |
+//| Compara cache de posições vs estado atual e emite eventos.        |
+//+------------------------------------------------------------------+
+int BuildPositionSnapshot(CachedPosition &snap[])
+{
+   int count = 0;
+   for(int i = 0; i < PositionsTotal() && count < MAX_CACHED_POSITIONS; i++)
+   {
+      ulong ticket = PositionGetTicket(i);
+      if(!PositionSelectByTicket(ticket))
+         continue;
+
+      long magic = PositionGetInteger(POSITION_MAGIC);
+      if(g_magic_number > 0 && magic != g_magic_number)
+         continue;
+
+      snap[count].position_id = PositionGetInteger(POSITION_IDENTIFIER);
+      snap[count].symbol      = PositionGetString(POSITION_SYMBOL);
+      snap[count].volume      = PositionGetDouble(POSITION_VOLUME);
+      snap[count].sl          = PositionGetDouble(POSITION_SL);
+      snap[count].tp          = PositionGetDouble(POSITION_TP);
+      snap[count].pos_type    = PositionGetInteger(POSITION_TYPE);
+      snap[count].magic       = magic;
+      count++;
+   }
+   return count;
+}
+
+void RefreshPositionCache()
+{
+   g_pos_cache_size = BuildPositionSnapshot(g_pos_cache);
+}
+
+void EmitSyntheticTradeEvent(const CachedPosition &cached, double closed_volume, double remaining_volume)
+{
+   JSONNode stream_msg;
+   stream_msg["type"]       = "STREAM";
+   stream_msg["event"]      = "TRADE_EVENT";
+   stream_msg["timestamp_mql"] = (long)TimeCurrent();
+   stream_msg["role"]       = g_role;
+   stream_msg["source"]     = "ONTRADE";
+
+   stream_msg["request_action"]       = 1;  // TRADE_ACTION_DEAL
+   stream_msg["request_order"]        = (long)0;
+   stream_msg["request_symbol"]       = cached.symbol;
+   stream_msg["request_volume"]       = closed_volume;
+   stream_msg["request_price"]        = 0.0;
+   stream_msg["request_sl"]           = 0.0;
+   stream_msg["request_tp"]           = 0.0;
+   stream_msg["request_deviation"]    = (long)0;
+   stream_msg["request_type"]         = (cached.pos_type == POSITION_TYPE_BUY) ? 1 : 0;
+   stream_msg["request_type_filling"] = 0;
+   stream_msg["request_comment"]      = "";
+   stream_msg["request_position"]     = cached.position_id;
+
+   stream_msg["result_retcode"] = (long)TRADE_RETCODE_DONE;
+   stream_msg["result_deal"]    = (long)0;
+   stream_msg["result_order"]   = (long)0;
+   stream_msg["result_volume"]  = closed_volume;
+   stream_msg["result_price"]   = 0.0;
+   stream_msg["result_comment"] = "detected by OnTrade";
+
+   stream_msg["position_volume_remaining"] = remaining_volume;
+   stream_msg["position_id"]               = cached.position_id;
+
+   if(!SendJsonMessage(stream_msg, "Event"))
+      Print("ERROR: Falha ao enviar TRADE_EVENT sintético via EventSocket");
+
+   PrintFormat("OnTrade: %s detectado (pos_id=%lld, symbol=%s, vol=%.2f, remaining=%.2f)",
+               (remaining_volume > 0) ? "PARTIAL_CLOSE" : "CLOSE",
+               cached.position_id, cached.symbol, closed_volume, remaining_volume);
+}
+
+void EmitSltpModified(const CachedPosition &old_pos, const CachedPosition &new_pos)
+{
+   JSONNode msg;
+   msg["type"]          = "STREAM";
+   msg["event"]         = "SLTP_MODIFIED";
+   msg["timestamp_mql"] = (long)TimeCurrent();
+   msg["role"]          = g_role;
+   msg["position_id"]   = new_pos.position_id;
+   msg["symbol"]        = new_pos.symbol;
+   msg["sl"]            = new_pos.sl;
+   msg["tp"]            = new_pos.tp;
+   msg["old_sl"]        = old_pos.sl;
+   msg["old_tp"]        = old_pos.tp;
+   msg["volume"]        = new_pos.volume;
+
+   if(!SendJsonMessage(msg, "Event"))
+      Print("ERROR: Falha ao enviar SLTP_MODIFIED via EventSocket");
+
+   PrintFormat("OnTrade: SL/TP modificado (pos_id=%lld, symbol=%s, sl=%.5f→%.5f, tp=%.5f→%.5f)",
+               new_pos.position_id, new_pos.symbol,
+               old_pos.sl, new_pos.sl, old_pos.tp, new_pos.tp);
+}
+
+void OnTrade()
+{
+   if(g_role != "MASTER" || !g_is_connected || g_magic_number == 0)
+      return;
+
+   CachedPosition new_snap[MAX_CACHED_POSITIONS];
+   int new_count = BuildPositionSnapshot(new_snap);
+
+   for(int i = 0; i < g_pos_cache_size; i++)
+   {
+      bool found = false;
+      for(int j = 0; j < new_count; j++)
+      {
+         if(g_pos_cache[i].position_id != new_snap[j].position_id)
+            continue;
+
+         found = true;
+
+         // Volume diminuiu → partial close externo
+         if(new_snap[j].volume < g_pos_cache[i].volume - 0.000001)
+         {
+            double closed_vol = g_pos_cache[i].volume - new_snap[j].volume;
+            EmitSyntheticTradeEvent(g_pos_cache[i], closed_vol, new_snap[j].volume);
+         }
+
+         // SL ou TP mudou
+         if(MathAbs(new_snap[j].sl - g_pos_cache[i].sl) > 0.000001
+            || MathAbs(new_snap[j].tp - g_pos_cache[i].tp) > 0.000001)
+         {
+            EmitSltpModified(g_pos_cache[i], new_snap[j]);
+         }
+         break;
+      }
+
+      if(!found)
+      {
+         // Posição desapareceu → fechamento total (SL/TP hit, SO, mobile close, etc.)
+         EmitSyntheticTradeEvent(g_pos_cache[i], g_pos_cache[i].volume, 0.0);
+      }
+   }
+
+   // Atualizar cache
+   g_pos_cache_size = new_count;
+   for(int i = 0; i < new_count; i++)
+   {
+      g_pos_cache[i].position_id = new_snap[i].position_id;
+      g_pos_cache[i].symbol      = new_snap[i].symbol;
+      g_pos_cache[i].volume      = new_snap[i].volume;
+      g_pos_cache[i].sl          = new_snap[i].sl;
+      g_pos_cache[i].tp          = new_snap[i].tp;
+      g_pos_cache[i].pos_type    = new_snap[i].pos_type;
+      g_pos_cache[i].magic       = new_snap[i].magic;
+   }
+}
+
+//+------------------------------------------------------------------+
 //| Bloco 5 - OnTradeTransaction                                    |
 //| Publica TRADE_EVENT via EventSocket para o Python.               |
 //| Ambos MASTER e SLAVE publicam, mas o Python só replica do MASTER.|
@@ -1656,6 +1827,10 @@ void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest 
    {
       Print("ERROR: Falha ao enviar TRADE_EVENT via EventSocket");
    }
+
+   // Atualizar cache após emitir TRADE_EVENT (dedup: OnTrade() não verá este diff)
+   if(request.action == TRADE_ACTION_DEAL)
+      RefreshPositionCache();
 
    // Nota: a detecção de ALIEN_TRADE foi movida para o caminho DEAL_ADD no topo desta
    // função. DEAL_ADD é a única fonte que dispara em TODOS os terminais da mesma conta


### PR DESCRIPTION
…s via OnTrade() snapshot

Master EA was missing close events when positions were closed by SL/TP hit, Stop Out, or external terminals (mobile/webtrader). OnTradeTransaction only fires REQUEST for local OrderSend calls, so broker-initiated closes were invisible to Python.

EA changes:
- Add position cache (CachedPosition struct) populated on init and after each TRADE_ACTION_DEAL in OnTradeTransaction (dedup with OnTrade)
- Add OnTrade() that diffs cache vs current positions:
  - Position disappeared → synthetic TRADE_EVENT (CLOSE)
  - Volume decreased → synthetic TRADE_EVENT (PARTIAL_CLOSE)
  - SL/TP changed → SLTP_MODIFIED event
- BuildPositionSnapshot() filters by magic number

Python changes:
- tcp_message_handler: route SLTP_MODIFIED events to copytrade_manager
- copytrade_manager: handle_master_sltp_update() replicates SL/TP to slaves via TRADE_POSITION_MODIFY (already supported by EA)
- DB migration: add sl/tp columns to open_positions

Resolves the SL/TP close bug and issue #92 (SL/TP replication). Requires EA recompilation in MetaEditor.

https://claude.ai/code/session_01LXm8hNiiAALympnh6Pwa9v