### PR TITLE
fix(ea): remove magic number filter from MASTER position snapshot

### DIFF
--- a/mt5_ea/ZmqTraderBridge.mq5
+++ b/mt5_ea/ZmqTraderBridge.mq5
@@ -1484,7 +1484,10 @@ int BuildPositionSnapshot(CachedPosition &snap[])
          continue;
 
       long magic = PositionGetInteger(POSITION_MAGIC);
-      if(g_magic_number > 0 && magic != g_magic_number)
+
+      // MASTER: rastrear TODAS as posições (usuário opera manualmente, magic=0)
+      // SLAVE: só nossas posições (magic match) — mas OnTrade() já retorna cedo para SLAVE
+      if(g_role == "SLAVE" && g_magic_number > 0 && magic != g_magic_number)
          continue;
 
       snap[count].position_id = PositionGetInteger(POSITION_IDENTIFIER);


### PR DESCRIPTION
On MASTER, positions are opened manually by the user (magic=0), but BuildPositionSnapshot was filtering by g_magic_number (123456789). This caused the cache to always be empty, so OnTrade() never detected any diffs — SL/TP modifications and TP/SL-hit closes were invisible.

Fix: only apply magic filter on SLAVE role. MASTER tracks all positions.

https://claude.ai/code/session_01LXm8hNiiAALympnh6Pwa9v