### PR TITLE
Parte 010 - Envio 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,15 @@ Tipos de mudança:
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-04-18
+
+### Fixed
+- **Master invertia direção e slave ficava com posição oposta** (#104): quando o master fazia uma ordem contrária com volume maior que a posição atual (cruzando zero em netting), o `POSITION_IDENTIFIER` permanecia estável mas `POSITION_TYPE` invertia — o diff do `OnTrade()` comparava apenas volume e classificava o evento como PARTIAL_CLOSE. Resultado: slave fechava parte da posição na direção antiga em vez de inverter, ficando LONG enquanto master ficava SHORT (e vice-versa). O EA agora compara também `POSITION_TYPE`; ao detectar inversão, emite um TRADE_EVENT sintético com `is_reversal=true` carregando `new_direction`, `new_volume` (excedente na perna nova) e `old_direction`/`old_volume`. O Python processa via fluxo de reversal (close da perna antiga + open na nova) usando diretamente os dados do evento, dispensando inferência do DB — evita o off-by-one do `master_volume_current` após cruzamentos de zero
+
 ### Changed
 - **EA renomeado**: `mt5_ea/ZmqTraderBridge.mq5` → `mt5_ea/EPCopyFlow2_EA.mq5` (nome antigo era legado da era ZMQ). Recompilar no MetaEditor para gerar `EPCopyFlow2_EA.ex5`
+- **Dedup de eventos do master**: em reversal sintético, ambos `order_type` (BUY=0 e SELL=1) são registrados no dedup com mesmo `(position_id, timestamp_mql)` — impede que o evento subsequente do `OnTradeTransaction` (com volume total da ordem) seja reprocessado como ADD ou abertura nova
+- Bump de versão: `0.1.1` → `0.1.2`
 
 ## [0.1.1] — 2026-04-18
 
@@ -79,7 +86,8 @@ Tipos de mudança:
 - Monitor de processo MT5 (detecta crash e reinicia)
 - Monitor de internet (detecta queda de conexão)
 
-[Unreleased]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/EPFILHO/EPCopyFlow2.0/releases/tag/v0.0.1

--- a/core/copytrade_manager.py
+++ b/core/copytrade_manager.py
@@ -459,12 +459,25 @@ class CopyTradeManager(QObject):
             logger.warning("Trade event sem símbolo, ignorando.")
             return
 
-        # Determinar tipo de ação para replicação
-        trade_action = self._classify_trade_action(action, order_type, position_ticket, position_volume_remaining)
-        logger.info(f"  trade_action={trade_action}")
-        if not trade_action:
-            logger.debug(f"Ação de trade não replicável: action={action}, type={order_type}")
-            return
+        # Reversal sintético do EA (OnTrade detectou cruzamento de zero em netting).
+        # O evento carrega new_direction/new_volume já calculados — dispensa inferir
+        # do DB e é imune ao bug em que o master_volume_current ficava dessincronizado
+        # após uma ordem oposta de volume maior que a posição.
+        is_reversal_event = bool(trade_event.get("is_reversal"))
+        new_direction = trade_event.get("new_direction")
+        new_volume = trade_event.get("new_volume")
+
+        if is_reversal_event:
+            trade_action = "REVERSAL"
+            logger.info(f"  🔄 REVERSAL sintético: {trade_event.get('old_direction')} {trade_event.get('old_volume')} "
+                        f"-> {new_direction} {new_volume}")
+        else:
+            # Determinar tipo de ação para replicação
+            trade_action = self._classify_trade_action(action, order_type, position_ticket, position_volume_remaining)
+            logger.info(f"  trade_action={trade_action}")
+            if not trade_action:
+                logger.debug(f"Ação de trade não replicável: action={action}, type={order_type}")
+                return
 
         # Validar que temos position_id (obrigatório para tracking)
         if not position_id:
@@ -481,6 +494,13 @@ class CopyTradeManager(QObject):
             logger.debug(f"  Evento duplicado ignorado: pos_id={position_id}, ts_mql={timestamp_mql}, action={trade_action}")
             return
         self._master_event_dedup[dedup_key] = now
+        # No reversal sintético, o OnTradeTransaction subsequente chega com o volume
+        # total da ordem (ex: BUY 0.14 fechando SELL 0.10 para abrir BUY 0.04) e
+        # seria reprocessado como BUY novo. Registrar ambos order_types no dedup
+        # impede esse reprocessamento — o evento sintético é a fonte de verdade.
+        if is_reversal_event:
+            opposite = 0 if order_type == 1 else 1
+            self._master_event_dedup[(position_id, timestamp_mql, opposite)] = now
         self._master_event_dedup = {k: v for k, v in self._master_event_dedup.items() if now - v < 10}
 
         # ── Serializar por position_id ──
@@ -492,8 +512,11 @@ class CopyTradeManager(QObject):
             self.copy_trade_log.emit(log_msg)
             logger.info(log_msg)
 
-            # Atualizar tracking master no DB (CLOSE/PARTIAL_CLOSE)
-            self._track_master_position(position_id, volume, trade_action)
+            # Atualizar tracking master no DB (CLOSE/PARTIAL_CLOSE).
+            # REVERSAL não atualiza aqui — o fluxo _execute_reversal cuida do DB
+            # via _on_close_success (perna antiga) + _on_open_success (perna nova).
+            if trade_action != "REVERSAL":
+                self._track_master_position(position_id, volume, trade_action)
 
             # Replica para cada slave conectado (em paralelo entre slaves)
             slaves = self.broker_manager.get_connected_slave_brokers()
@@ -506,7 +529,9 @@ class CopyTradeManager(QObject):
 
                 tasks.append(self._replicate_to_slave(
                     slave_key, master_broker, deal_ticket, position_id,
-                    trade_action, symbol, volume, order_type, price, sl, tp
+                    trade_action, symbol, volume, order_type, price, sl, tp,
+                    reversal_new_direction=new_direction if is_reversal_event else None,
+                    reversal_new_volume=new_volume if is_reversal_event else None,
                 ))
 
             if tasks:
@@ -650,7 +675,9 @@ class CopyTradeManager(QObject):
     async def _replicate_to_slave(self, slave_key: str, master_broker: str,
                                    deal_ticket: int, position_id: int,
                                    trade_action: str, symbol: str, volume: float,
-                                   order_type: int, price: float, sl: float, tp: float):
+                                   order_type: int, price: float, sl: float, tp: float,
+                                   reversal_new_direction: str = None,
+                                   reversal_new_volume: float = None):
         """
         Envia comando de trade para um slave específico (NETTING mode).
 
@@ -677,6 +704,35 @@ class CopyTradeManager(QObject):
         existing_slave_vol = pos_info["volume"] if pos_info else 0.0
         existing_direction = pos_info["direction"] if pos_info else None
         master_prev_vol = pos_info["master_volume"] if pos_info else 0.0
+
+        # ── REVERSAL sintético (EA detectou cruzamento de zero via OnTrade) ──
+        # O EA já entregou new_direction/new_volume — não dependemos do DB
+        # pro master_prev_vol, que estaria desatualizado após o cruzamento.
+        if trade_action == "REVERSAL":
+            new_vol = float(reversal_new_volume or 0.0)
+            new_dir = reversal_new_direction or ("BUY" if order_type == 0 else "SELL")
+            if has_open_position:
+                await self._execute_reversal(
+                    slave_key, master_broker, deal_ticket, position_id, symbol,
+                    new_vol, new_dir, new_vol, multiplier,
+                    existing_slave_vol, symbol_specs, sl, tp
+                )
+                return
+            # Slave sem posição (floor anterior zerou ou slave nunca entrou):
+            # abre direto na direção nova com o volume da perna nova.
+            slave_lot = self.calculate_slave_lot(new_vol, multiplier, symbol_specs)
+            if slave_lot <= 0:
+                logger.info(f"    🔄 REVERSAL sem posição: {new_vol} × {multiplier} < volume_min. Slave fica zerado.")
+                self._insert_history(master_broker, deal_ticket, symbol, f"REVERSAL_{new_dir}",
+                                     new_vol, slave_key, 0, 0, "SKIPPED",
+                                     "excess < volume_min (slave sem posição prévia)")
+                return
+            logger.info(f"    🔄 REVERSAL sem posição: abrindo {new_dir} {slave_lot} direto")
+            await self._send_open_command(
+                slave_key, master_broker, deal_ticket, position_id, symbol,
+                new_vol, slave_lot, new_dir, 0.0, sl, tp
+            )
+            return
 
         # ── CLOSE TOTAL ──
         if trade_action == "CLOSE":

--- a/core/tcp_message_handler.py
+++ b/core/tcp_message_handler.py
@@ -161,6 +161,12 @@ class TcpMessageHandler(QObject):
                 "result": result,
                 "position_volume_remaining": message.get("position_volume_remaining"),
                 "position_id": message.get("position_id", 0),
+                "source": message.get("source", ""),
+                "is_reversal": bool(message.get("is_reversal", False)),
+                "old_direction": message.get("old_direction"),
+                "new_direction": message.get("new_direction"),
+                "old_volume": message.get("old_volume"),
+                "new_volume": message.get("new_volume"),
             }
             self.trade_event_received.emit(trade_event_data)
             logger.info(f"TRADE_EVENT de {identified_broker_key} - symbol={request.get('symbol', 'N/A')}")

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
 #   MINOR: features novas (backward-compatible)
 #   PATCH: bugfixes (backward-compatible)
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/mt5_ea/EPCopyFlow2_EA.mq5
+++ b/mt5_ea/EPCopyFlow2_EA.mq5
@@ -1547,6 +1547,58 @@ void EmitSyntheticTradeEvent(const CachedPosition &cached, double closed_volume,
                cached.position_id, cached.symbol, closed_volume, remaining_volume);
 }
 
+void EmitReversalEvent(const CachedPosition &old_pos, const CachedPosition &new_pos)
+{
+   // Em netting, uma ordem oposta de volume maior que a posição atual faz o
+   // POSITION_IDENTIFIER permanecer, POSITION_TYPE inverter e POSITION_VOLUME
+   // virar o excedente na direção nova. OnTradeTransaction reporta a ordem
+   // original (volume total), mas não sinaliza a inversão — detectamos aqui.
+   JSONNode stream_msg;
+   stream_msg["type"]       = "STREAM";
+   stream_msg["event"]      = "TRADE_EVENT";
+   stream_msg["timestamp_mql"] = (long)TimeCurrent();
+   stream_msg["role"]       = g_role;
+   stream_msg["source"]     = "ONTRADE_REVERSAL";
+   stream_msg["is_reversal"] = true;
+
+   stream_msg["request_action"]       = 1;  // TRADE_ACTION_DEAL
+   stream_msg["request_order"]        = (long)0;
+   stream_msg["request_symbol"]       = new_pos.symbol;
+   stream_msg["request_volume"]       = new_pos.volume;
+   stream_msg["request_price"]        = 0.0;
+   stream_msg["request_sl"]           = 0.0;
+   stream_msg["request_tp"]           = 0.0;
+   stream_msg["request_deviation"]    = (long)0;
+   // request_type reflete a direção da NOVA perna
+   stream_msg["request_type"]         = (int)new_pos.pos_type;
+   stream_msg["request_type_filling"] = 0;
+   stream_msg["request_comment"]      = "";
+   stream_msg["request_position"]     = (long)0;
+
+   stream_msg["result_retcode"] = (long)TRADE_RETCODE_DONE;
+   stream_msg["result_deal"]    = (long)0;
+   stream_msg["result_order"]   = (long)0;
+   stream_msg["result_volume"]  = new_pos.volume;
+   stream_msg["result_price"]   = 0.0;
+   stream_msg["result_comment"] = "reversal detected by OnTrade";
+
+   // Campos específicos do reversal (Python usa diretamente, sem inferir do DB)
+   stream_msg["old_direction"] = (old_pos.pos_type == POSITION_TYPE_BUY) ? "BUY" : "SELL";
+   stream_msg["new_direction"] = (new_pos.pos_type == POSITION_TYPE_BUY) ? "BUY" : "SELL";
+   stream_msg["old_volume"]    = old_pos.volume;
+   stream_msg["new_volume"]    = new_pos.volume;
+   stream_msg["position_volume_remaining"] = new_pos.volume;
+   stream_msg["position_id"]               = new_pos.position_id;
+
+   if(!SendJsonMessage(stream_msg, "Event"))
+      Print("ERROR: Falha ao enviar REVERSAL TRADE_EVENT via EventSocket");
+
+   PrintFormat("OnTrade: REVERSAL detectado (pos_id=%lld, symbol=%s, %s %.2f -> %s %.2f)",
+               new_pos.position_id, new_pos.symbol,
+               (old_pos.pos_type == POSITION_TYPE_BUY) ? "BUY" : "SELL", old_pos.volume,
+               (new_pos.pos_type == POSITION_TYPE_BUY) ? "BUY" : "SELL", new_pos.volume);
+}
+
 void EmitSltpModified(const CachedPosition &old_pos, const CachedPosition &new_pos)
 {
    JSONNode msg;
@@ -1588,7 +1640,16 @@ void OnTrade()
 
          found = true;
 
-         // Volume diminuiu → partial close externo
+         // pos_type mudou → reversal em netting (ordem oposta com volume > posição atual).
+         // Precisa vir ANTES do diff de volume: o volume "diminuiu" visualmente mas a
+         // direção virou — tratar como partial close produziria slave em direção oposta.
+         if(new_snap[j].pos_type != g_pos_cache[i].pos_type)
+         {
+            EmitReversalEvent(g_pos_cache[i], new_snap[j]);
+            break;
+         }
+
+         // Volume diminuiu → partial close externo (mesma direção)
          if(new_snap[j].volume < g_pos_cache[i].volume - 0.000001)
          {
             double closed_vol = g_pos_cache[i].volume - new_snap[j].volume;


### PR DESCRIPTION
…orrectly (#104)

Quando o master fazia uma ordem oposta de volume maior que a posição atual (cruzando zero em netting), o POSITION_IDENTIFIER permanecia estável mas o POSITION_TYPE invertia. O diff do OnTrade() só comparava volume e classificava o evento como PARTIAL_CLOSE, deixando o slave LONG enquanto o master virava SHORT (e vice-versa).

- EA: OnTrade() agora compara pos_type além de volume. Ao detectar inversão, emite TRADE_EVENT sintético com is_reversal=true, new_direction, new_volume (excedente na perna nova) e old_direction/old_volume
- Python: handle_master_trade_event reconhece is_reversal e dispara o fluxo _execute_reversal com dados do evento (não depende de master_volume_current do DB, que ficaria off-by-one após o cruzamento de zero)
- Python: dedup registra ambos order_types (BUY=0 e SELL=1) no mesmo (position_id, timestamp_mql) quando há reversal — impede que o evento subsequente do OnTradeTransaction (com volume total da ordem) seja reprocessado como ADD ou abertura nova
- Versão: 0.1.1 → 0.1.2

Recompilar o EA no MetaEditor para gerar EPCopyFlow2_EA.ex5.

https://claude.ai/code/session_01XhuNTWHRp1QfC2wDAYjeiv