### PR TITLE
fix(ea): fallback ORDER_POSITION_ID quando result.deal=0 em conta real - Parte 011 - 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Tipos de mudança:
 
 ## [Unreleased]
 
+## [0.1.8] — 2026-04-23
+
+### Fixed
+- **`position_id=0` em conta real com execução assíncrona na B3** (#109): em corretoras reais, `OrderSend` retorna com `result.deal=0` (o deal é confirmado assincronamente pela bolsa). As duas tentativas existentes de derivar o `POSITION_IDENTIFIER` (`HistoryDealSelect` e `PositionSelect`) falhavam nesse cenário, fazendo o Python rejeitar o TRADE_EVENT com `❌ TRADE_EVENT sem position_id!` e não replicar a abertura para os slaves. Adicionada **3ª tentativa** via `HistoryOrderGetInteger(result.order, ORDER_POSITION_ID)`: a ordem já existe no histórico com `ORDER_POSITION_ID` preenchido mesmo antes do deal ser confirmado. Fix cirúrgico no EA (`EPCopyFlow2_EA.mq5`); comportamento em conta demo inalterado.
+- Bump de versão: `0.1.7` → `0.1.8`
+
 ## [0.1.7] — 2026-04-19
 
 ### Changed
@@ -134,7 +140,8 @@ Tipos de mudança:
 - Monitor de processo MT5 (detecta crash e reinicia)
 - Monitor de internet (detecta queda de conexão)
 
-[Unreleased]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.7...HEAD
+[Unreleased]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.4...v0.1.5

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
 #   MINOR: features novas (backward-compatible)
 #   PATCH: bugfixes (backward-compatible)
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/mt5_ea/EPCopyFlow2_EA.mq5
+++ b/mt5_ea/EPCopyFlow2_EA.mq5
@@ -1867,6 +1867,14 @@ void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest 
          }
       }
 
+      // 3ª tentativa: ORDER_POSITION_ID via histórico da ordem.
+      // Cobre o caso de conta real onde result.deal chega zero (execução assíncrona na bolsa):
+      // a ordem já existe no histórico com ORDER_POSITION_ID preenchido mesmo sem deal confirmado.
+      if(position_id == 0 && result.order > 0 && HistoryOrderSelect(result.order))
+      {
+         position_id = HistoryOrderGetInteger(result.order, ORDER_POSITION_ID);
+      }
+
       if(position_id == 0 && InpDebugLog)
          PrintFormat("WARNING: Não foi possível obter POSITION_IDENTIFIER para %s (deal=%lld, pos=%lld)",
                      request.symbol, result.deal, request.position);


### PR DESCRIPTION
Em corretoras reais (B3), OrderSend retorna com result.deal=0 porque o deal é confirmado assincronamente pela bolsa. A 1ª tentativa (HistoryDealSelect) e a 2ª (PositionSelect) falhavam nesse cenário, causando position_id=0 e rejeição do TRADE_EVENT no Python.

Adicionada 3ª tentativa via HistoryOrderGetInteger(result.order, ORDER_POSITION_ID): a ordem já existe no histórico com ORDER_POSITION_ID preenchido mesmo antes do deal ser liquidado. Padrão documentado em https://www.mql5.com/en/forum/496676.

Em conta demo o deal vem preenchido sincronamente — comportamento inalterado. Issue #109 criada para rastrear migração futura ao padrão ouro MetaQuotes (centralizar emissão em OnTradeTransaction).

Closes: relacionado a #109

https://claude.ai/code/session_018HcYZUCPXZQro2osaWGRXG