### PR TITLE
Parte 012 - envio 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Tipos de mudança:
 
 ## [Unreleased]
 
+### Added
+- **`core/engine_thread.py`** (#111, PR 1): infraestrutura `EngineThread` para hospedar o event loop do motor de trade em uma thread daemon dedicada, isolada da main thread (Qt). API mínima: `start()` (bloqueia até loop pronto via `threading.Event`), `submit(coro) -> concurrent.futures.Future` (wrapper sobre `asyncio.run_coroutine_threadsafe`), `stop(timeout)` (cancela tasks pendentes, para o loop, faz join). Inclui `loop.set_exception_handler` para que exceções em coroutines/tasks não derrubem o loop. Acompanhada de `tests/test_engine_thread.py` (13 testes unitários, stdlib `unittest`). **Não conectada ao app ainda** — primeiro passo da refatoração para separar GUI Qt e motor asyncio em threads distintas (resolve freeze de replicação durante Alt+Tab no Windows).
+
 ## [0.1.8] — 2026-04-23
 
 ### Fixed

--- a/core/engine_thread.py
+++ b/core/engine_thread.py
@@ -1,0 +1,169 @@
+# EPCopyFlow 2.0
+# core/engine_thread.py
+# Thread dedicada que hospeda o event loop do motor de trade (asyncio),
+# isolando-o do event loop da GUI (Qt main thread). Ver issue #111.
+#
+# Uso:
+#     engine = EngineThread(name="AsyncEngine")
+#     engine.start()                          # bloqueia até loop estar pronto
+#     fut = engine.submit(some_coroutine())   # concurrent.futures.Future
+#     engine.stop(timeout=5.0)
+#
+# Esta classe é deliberadamente neutra: não conhece Qt, TcpRouter,
+# CopyTradeManager ou qualquer outro componente do app. O bootstrap
+# do motor (construir QObjects DENTRO desta thread) é responsabilidade
+# do main.py, via `engine.submit(bootstrap_coro())`.
+
+import asyncio
+import concurrent.futures
+import logging
+import threading
+from typing import Coroutine, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class EngineThread:
+    """
+    Hospeda um event loop asyncio em uma thread daemon dedicada.
+
+    Garantias:
+    - `start()` só retorna quando o loop está rodando e pronto para receber `submit`.
+    - `submit(coro)` é thread-safe e retorna um `concurrent.futures.Future`.
+    - Exceções dentro de coroutines submetidas NÃO derrubam o loop;
+      ficam disponíveis no Future retornado por `submit`.
+    - `stop()` cancela tasks pendentes, para o loop e faz join da thread.
+    """
+
+    def __init__(self, name: str = "AsyncEngine", ready_timeout: float = 5.0):
+        self._name = name
+        self._ready_timeout = ready_timeout
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._ready = threading.Event()
+        self._stopped = False
+        self._lock = threading.Lock()
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        """Event loop hospedado pela thread. Disponível após `start()`."""
+        if self._loop is None:
+            raise RuntimeError("EngineThread.start() ainda não foi chamado.")
+        return self._loop
+
+    @property
+    def is_running(self) -> bool:
+        return (
+            self._thread is not None
+            and self._thread.is_alive()
+            and self._loop is not None
+            and self._loop.is_running()
+        )
+
+    def start(self) -> None:
+        """
+        Inicia a thread e o event loop. Bloqueia até o loop estar pronto.
+        Chamadas múltiplas são idempotentes (no-op se já iniciado).
+        """
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                logger.warning("EngineThread já está rodando — start() ignorado.")
+                return
+            if self._stopped:
+                raise RuntimeError("EngineThread já foi parado e não pode ser reiniciado.")
+
+            self._ready.clear()
+            self._thread = threading.Thread(
+                target=self._run, name=self._name, daemon=True
+            )
+            self._thread.start()
+
+        if not self._ready.wait(timeout=self._ready_timeout):
+            raise RuntimeError(
+                f"EngineThread não ficou pronto em {self._ready_timeout}s."
+            )
+        logger.info(f"EngineThread '{self._name}' iniciada e pronta.")
+
+    def _run(self) -> None:
+        loop = asyncio.new_event_loop()
+        self._loop = loop
+        asyncio.set_event_loop(loop)
+        loop.set_exception_handler(self._loop_exception_handler)
+        try:
+            loop.call_soon(self._ready.set)
+            loop.run_forever()
+        finally:
+            try:
+                self._drain(loop)
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
+                logger.info(f"EngineThread '{self._name}' loop encerrado.")
+
+    @staticmethod
+    def _loop_exception_handler(loop: asyncio.AbstractEventLoop, context: dict) -> None:
+        # Loga e segue: uma exceção em callback/Future não derruba o loop.
+        msg = context.get("message") or "unhandled exception in engine loop"
+        exc = context.get("exception")
+        if exc is not None:
+            logger.error(f"[EngineThread] {msg}", exc_info=exc)
+        else:
+            logger.error(f"[EngineThread] {msg} | context={context}")
+
+    @staticmethod
+    def _drain(loop: asyncio.AbstractEventLoop) -> None:
+        """Cancela tasks pendentes e roda o loop até elas finalizarem."""
+        pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+        if not pending:
+            return
+        logger.info(f"[EngineThread] cancelando {len(pending)} task(s) pendente(s).")
+        for task in pending:
+            task.cancel()
+        try:
+            loop.run_until_complete(
+                asyncio.gather(*pending, return_exceptions=True)
+            )
+        except Exception:
+            logger.exception("[EngineThread] erro ao drenar tasks pendentes.")
+
+    def submit(self, coro: Coroutine) -> concurrent.futures.Future:
+        """
+        Agenda `coro` no loop do motor a partir de qualquer thread.
+        Retorna um `concurrent.futures.Future` com o resultado/exceção.
+        """
+        if not asyncio.iscoroutine(coro):
+            raise TypeError(
+                f"submit() espera uma coroutine, recebeu {type(coro).__name__}."
+            )
+        if self._loop is None or not self._loop.is_running():
+            # Fecha a coroutine para evitar warning "never awaited".
+            coro.close()
+            raise RuntimeError("EngineThread não está rodando — não é possível submit().")
+        return asyncio.run_coroutine_threadsafe(coro, self._loop)
+
+    def stop(self, timeout: float = 5.0) -> bool:
+        """
+        Para o loop ordenadamente: cancela tasks pendentes, para o loop e
+        faz join da thread. Retorna True se a thread terminou dentro do timeout.
+        Idempotente.
+        """
+        with self._lock:
+            if self._stopped:
+                return True
+            if self._thread is None:
+                self._stopped = True
+                return True
+            self._stopped = True
+
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            loop.call_soon_threadsafe(loop.stop)
+
+        self._thread.join(timeout=timeout)
+        alive = self._thread.is_alive()
+        if alive:
+            logger.warning(
+                f"EngineThread '{self._name}' não terminou em {timeout}s "
+                f"(thread ainda viva — possível coroutine travada)."
+            )
+        return not alive

--- a/tests/test_engine_thread.py
+++ b/tests/test_engine_thread.py
@@ -1,0 +1,171 @@
+# EPCopyFlow 2.0
+# tests/test_engine_thread.py
+# Testes unitários do EngineThread (issue #111, PR 1).
+#
+# Rodar:
+#     python -m unittest tests.test_engine_thread -v
+
+import asyncio
+import concurrent.futures
+import threading
+import time
+import unittest
+
+from core.engine_thread import EngineThread
+
+
+class EngineThreadTests(unittest.TestCase):
+    def setUp(self):
+        self.engine = EngineThread(name="TestEngine", ready_timeout=2.0)
+
+    def tearDown(self):
+        # Garantia de cleanup mesmo se um teste falhar antes do stop.
+        try:
+            self.engine.stop(timeout=2.0)
+        except Exception:
+            pass
+
+    # ---------- start ----------
+
+    def test_start_brings_loop_up_in_background_thread(self):
+        self.engine.start()
+        self.assertTrue(self.engine.is_running)
+        self.assertTrue(self.engine.loop.is_running())
+        # Thread do motor deve ser distinta da thread principal.
+        self.assertNotEqual(threading.current_thread().ident, self._engine_thread_ident())
+
+    def test_start_is_idempotent(self):
+        self.engine.start()
+        self.engine.start()  # não deve falhar
+        self.assertTrue(self.engine.is_running)
+
+    def test_loop_property_raises_before_start(self):
+        with self.assertRaises(RuntimeError):
+            _ = self.engine.loop
+
+    # ---------- submit ----------
+
+    def test_submit_returns_concurrent_future_with_result(self):
+        self.engine.start()
+
+        async def add(a, b):
+            return a + b
+
+        fut = self.engine.submit(add(2, 3))
+        self.assertIsInstance(fut, concurrent.futures.Future)
+        self.assertEqual(fut.result(timeout=2.0), 5)
+
+    def test_submit_runs_in_engine_thread_not_caller(self):
+        self.engine.start()
+        engine_ident = self._engine_thread_ident()
+
+        async def who_am_i():
+            return threading.current_thread().ident
+
+        ident = self.engine.submit(who_am_i()).result(timeout=2.0)
+        self.assertEqual(ident, engine_ident)
+        self.assertNotEqual(ident, threading.current_thread().ident)
+
+    def test_submit_rejects_non_coroutine(self):
+        self.engine.start()
+        with self.assertRaises(TypeError):
+            self.engine.submit(lambda: 42)
+
+    def test_submit_before_start_raises(self):
+        async def noop():
+            return None
+
+        coro = noop()
+        with self.assertRaises(RuntimeError):
+            self.engine.submit(coro)
+
+    # ---------- robustez: exceção em coro não derruba o loop ----------
+
+    def test_exception_in_coro_does_not_kill_loop(self):
+        self.engine.start()
+
+        async def boom():
+            raise ValueError("explode")
+
+        bad = self.engine.submit(boom())
+        with self.assertRaises(ValueError):
+            bad.result(timeout=2.0)
+
+        # Loop deve continuar saudável depois da exceção.
+        self.assertTrue(self.engine.is_running)
+
+        async def healthy():
+            return "ok"
+
+        good = self.engine.submit(healthy())
+        self.assertEqual(good.result(timeout=2.0), "ok")
+
+    def test_unobserved_exception_does_not_kill_loop(self):
+        """Exceção em task fire-and-forget também não pode derrubar o loop."""
+        self.engine.start()
+
+        async def schedule_unobserved():
+            asyncio.get_running_loop().create_task(self._raise_async())
+
+        self.engine.submit(schedule_unobserved()).result(timeout=2.0)
+        # Espera curta para o handler de exceção rodar.
+        time.sleep(0.1)
+        self.assertTrue(self.engine.is_running)
+
+        async def ping():
+            return "pong"
+
+        self.assertEqual(self.engine.submit(ping()).result(timeout=2.0), "pong")
+
+    @staticmethod
+    async def _raise_async():
+        raise RuntimeError("unobserved")
+
+    # ---------- stop ----------
+
+    def test_stop_returns_true_within_timeout(self):
+        self.engine.start()
+        self.assertTrue(self.engine.stop(timeout=2.0))
+        self.assertFalse(self.engine.is_running)
+
+    def test_stop_cancels_pending_tasks(self):
+        self.engine.start()
+
+        # Agenda uma coroutine que dorme bem mais do que o timeout do stop.
+        async def long_sleep():
+            await asyncio.sleep(60)
+
+        self.engine.submit(long_sleep())
+
+        t0 = time.monotonic()
+        finished = self.engine.stop(timeout=3.0)
+        elapsed = time.monotonic() - t0
+
+        self.assertTrue(finished)
+        # Stop deve ter sido bem mais rápido que os 60s da coro.
+        self.assertLess(elapsed, 3.0)
+
+    def test_stop_is_idempotent(self):
+        self.engine.start()
+        self.assertTrue(self.engine.stop(timeout=2.0))
+        # Segundo stop não deve travar nem lançar.
+        self.assertTrue(self.engine.stop(timeout=1.0))
+
+    def test_cannot_restart_after_stop(self):
+        self.engine.start()
+        self.engine.stop(timeout=2.0)
+        with self.assertRaises(RuntimeError):
+            self.engine.start()
+
+    # ---------- helpers ----------
+
+    def _engine_thread_ident(self):
+        # Acessa atributo privado só para teste — única forma de provar
+        # que a coro rodou na thread do motor.
+        thr = self.engine._thread
+        self.assertIsNotNone(thr)
+        return thr.ident
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…p (#111)

PR 1 da refatoração da issue #111. Adiciona core/engine_thread.py com classe EngineThread que hospeda um event loop asyncio em thread daemon dedicada, isolando-o da main thread (Qt). API mínima: start (bloqueia até o loop estar pronto via threading.Event), submit (wrapper sobre asyncio.run_coroutine_threadsafe retornando concurrent.futures.Future) e stop (cancela tasks pendentes, para o loop e faz join da thread).

set_exception_handler do loop garante que exceções em coroutines ou tasks fire-and-forget não derrubem o loop — apenas são logadas.

Acompanhado de tests/test_engine_thread.py com 13 testes unitários (stdlib unittest, sem dep nova): start idempotente, submit cross-thread, exceção observada/não-observada, stop com cancelamento, restart proibido.

Nenhum arquivo existente é alterado. A integração no bootstrap (trocar QtAsyncio por app.exec + EngineThread) virá no PR 2.