### PR TITLE
chore: post-refactor cleanup pass after issue #111 PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,36 @@ Tipos de mudança:
 - **Dívida técnica registrada (não corrigida neste PR)**: como o Python loga falha por timeout enquanto o broker pode confirmar a operação tardiamente (ex.: trade do XP foi executado com `retcode: 10009` mas o registro local já tinha sido marcado como falha), o DB do copytrade pode ficar inconsistente com a realidade do broker em cenários de throttle severo. Natureza similar (mas independente) do que motivou #56. Tratamento adequado fica para issue futura — depende de medirmos se o `HIGH_PRIORITY_CLASS` por si só já elimina o cenário em produção real.
 
 ### Changed
+- **Limpeza geral de código pós-refactor** (#111, follow-up): aplicada após
+  review automatizado dos PRs 2.5/2.6/B/3. Mudanças:
+  - **Índice em `copytrade_history(timestamp)`** (`_init_db`): `_fetch_today_stats`
+    e `_fetch_trade_history` faziam full scan; com a tabela crescendo, o WHERE
+    timestamp + ORDER BY DESC ficavam lentos. `CREATE INDEX IF NOT EXISTS` no
+    init resolve.
+  - **Debounce de 200ms em `dashboard_page.refresh_stats`**: cada
+    `copy_trade_executed`/`copy_trade_failed` disparava `request_today_stats`.
+    Em real-B3 com burst de trades isso geraria múltiplas queries por segundo.
+    Coalesce via `QTimer.singleShot(200)` → max 1 refresh por janela de 200ms.
+  - **Remoção de `sys.platform.startswith("win")` redundante** em
+    `broker_manager.py::connect_broker` e `mt5_process_monitor.py::restart_mt5_instance`:
+    `disable_power_throttling` já checa internamente e retorna False fora do
+    Windows. Também removido `import sys` órfão de `mt5_process_monitor.py`.
+  - **Refator de `CopyTradeManager.close()`**: extraído `_do_close()` como
+    helper síncrono compartilhado entre o caminho com engine (via
+    `engine.submit(_async_close)` + `result(timeout=2.0)`) e o caminho sem
+    engine (test environment). Elimina duplicação do `try/except/finally` que
+    existia em 2 lugares.
+  - **Round defensivo no log de ADD ok**: linha
+    `📊 ADD ok: +0.05 (slave: 0.1 → 0.15000000000000002)` (ruído de aritmética
+    float em SQLite/Python) virou `slave: 0.1 → 0.15`. Cosmético.
+  - **Comentários enxugados**: removidas referências "PR X troca por Y", "issue
+    #111", anedotas tipo "respostas demorando 25s+", e Slot docstrings óbvios
+    ("roda na main thread") em `copytrade_manager.py`, `broker_manager.py`,
+    `mt5_process_monitor.py`, `win_process.py`, `history_page.py`,
+    `dashboard_page.py`, `notification_center.py`, `main_window.py`. O CHANGELOG
+    e o histórico git já documentam o "porquê" histórico — código mantém só o
+    "porquê" intemporal.
+
 - **SQLite confinado ao thread do motor** (#111, PR 3): fim da solução intermediária do PR 2. `CopyTradeManager` agora usa conexão SQLite com `check_same_thread` default (sem flag de bypass) e **sem locks** — engine asyncio é single-threaded, então não há contenção possível. Leituras pedidas pela GUI seguem padrão **request + fetch async + signal**: `request_trade_history()` / `request_today_stats()` (sync, qualquer thread) submetem coroutine ao motor via `engine.submit()`; coroutines `_fetch_trade_history` / `_fetch_today_stats` rodam no motor, fazem a query e emitem 2 sinais novos (`trade_history_ready(list, str)`, `today_stats_ready(dict)`) via cross-thread queued connection — slots na main thread atualizam UI quando o resultado chega. `close()` virou wrapper que submete `_async_close` ao motor (com `result(timeout=2.0)`) — garante que o `db.close()` aconteça na thread certa antes do `engine.stop()`. Wire de `copytrade_manager.engine` feito em `main.py` após o bootstrap (mesmo padrão do `tcp_message_handler`). `gui/pages/history_page.py` e `gui/pages/dashboard_page.py` adaptados: conectam aos sinais no `__init__` e disparam `request_*()` em vez do antigo `get_*()` síncrono. Resultado: zero risco de contenção SQLite entre motor e GUI; código também fica mais simples (não precisa mais de `threading` import em `copytrade_manager.py`).
 - **Bootstrap separado em GUI thread (Qt) e motor thread (asyncio)** (#111, PR 2): mudança arquitetural atômica. `main.py` reescrito: removida dependência de `PySide6.QtAsyncio`/`qasync`, `app.exec()` padrão volta a ser o event loop da main thread. Um `EngineThread` dedicado hospeda o loop do motor — `TcpRouter`, `CopyTradeManager` e `TcpMessageHandler` são construídos **dentro** desse thread (via coroutine de bootstrap submetida à engine), garantindo thread affinity Qt correta dos QObjects emissores. Isso resolve o **freeze de replicação durante Alt+Tab** observado em produção (B3): com a única main thread, Windows throttlava CPU do motor junto com a GUI; agora o motor compete por CPU em pé de igualdade com a GUI dentro do processo.
 - **`BrokerManager`**: recebe parâmetro `engine` no construtor. Os 3 sites que usavam `asyncio.create_task(...)` em `connect_broker`/`disconnect_broker` (chamados da main thread via botões) viraram `engine.submit(...)`. Adicionado `threading.RLock` (`_state_lock`) protegendo `connected_brokers` e `mt5_processes`. Novos acessores thread-safe: `set_mt5_process`, `set_connected`, `get_mt5_process`.

--- a/core/broker_manager.py
+++ b/core/broker_manager.py
@@ -361,14 +361,12 @@ class BrokerManager(QObject):
 
         try:
             logger.info(f"Iniciando MT5 para {key}...")
+            # HIGH_PRIORITY_CLASS + disable_power_throttling: evitam throttle do
+            # Windows quando o terminal perde foco (Alt+Tab).
             if sys.platform.startswith("win"):
                 si = subprocess.STARTUPINFO()
                 si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
                 si.wShowWindow = 6  # SW_MINIMIZE
-                # HIGH_PRIORITY_CLASS evita que o Windows throttle o processo MT5
-                # quando a janela perde foco (Alt+Tab). Sem isso, observamos
-                # respostas de TRADE_POSITION_CLOSE_ID demorando 25s+ em slaves
-                # ociosos enquanto o usuário estava em outra janela.
                 process = subprocess.Popen(
                     [instance_path, "/portable"],
                     cwd=os.path.dirname(instance_path),
@@ -385,10 +383,7 @@ class BrokerManager(QObject):
                 self.connected_brokers[key] = True
             logger.info(f"MT5 iniciado para {key}.")
 
-            # EcoQoS opt-out: HIGH_PRIORITY_CLASS sozinho não impede o Windows
-            # de marcar o processo como "Eco" quando perde foco. Esta chamada
-            # via SetProcessInformation desliga o throttle de execution speed.
-            if sys.platform.startswith("win") and disable_power_throttling(process.pid):
+            if disable_power_throttling(process.pid):
                 logger.debug(f"Power throttling desligado para {key} (pid={process.pid}).")
 
             if self.tcp_router:

--- a/core/copytrade_manager.py
+++ b/core/copytrade_manager.py
@@ -23,9 +23,8 @@ class CopyTradeManager(QObject):
     copy_trade_log = Signal(str)
     emergency_completed = Signal(bool, str)  # (success, message)
 
-    # Sinais usados pelo padrão signal-based de leitura (PR 3, issue #111):
     # GUI chama request_*(), motor executa _fetch_*() e emite o sinal
-    # cross-thread. Slot na main thread atualiza UI.
+    # cross-thread; slot na main thread atualiza UI.
     trade_history_ready = Signal(list, str)   # (rows, broker_key_filter)
     today_stats_ready = Signal(dict)          # {"total", "success", "failed"}
 
@@ -43,19 +42,13 @@ class CopyTradeManager(QObject):
         self._position_locks = {}  # position_id -> asyncio.Lock (serializa eventos do mesmo position_id)
         self._master_event_dedup = {}  # (position_id, timestamp_mql) -> process_time
 
-        # SQLite confinado à thread do motor (PR 3, issue #111):
-        # - CopyTradeManager é construído DENTRO do motor (bootstrap_engine).
-        # - Connection nasce na thread do motor; check_same_thread default
-        #   garante que só ela toca o DB.
-        # - Leituras pedidas pela GUI vão via request_*() → engine.submit() →
-        #   _fetch_*() (motor) → signal cross-thread → slot na GUI.
-        # - Engine asyncio é single-threaded: zero locks necessários.
+        # SQLite confinado à thread do motor: connection nasce em
+        # bootstrap_engine, leituras da GUI vão via request_*() + signal.
+        # Engine é single-threaded asyncio, então zero locks.
         self.db = sqlite3.connect(DB_FILE)
         self._init_db()
 
-        # Wire pelo main.py após bootstrap (mesmo padrão do tcp_message_handler).
-        # Necessário para request_trade_history / request_today_stats / close().
-        self.engine = None
+        self.engine = None  # wired pelo main.py após bootstrap_engine.
 
         logger.info("CopyTradeManager inicializado.")
 
@@ -155,6 +148,14 @@ class CopyTradeManager(QObject):
                 logger.info(f"Migração: coluna '{col_name}' adicionada a {table}.")
             except sqlite3.OperationalError:
                 pass  # Coluna já existe
+
+        # Índice em timestamp acelera get_today_stats e ORDER BY DESC do
+        # get_trade_history quando a tabela cresce.
+        self.db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_copytrade_history_timestamp "
+            "ON copytrade_history(timestamp)"
+        )
+        self.db.commit()
 
         logger.info("Banco de dados SQLite inicializado (4 tabelas).")
 
@@ -1108,7 +1109,8 @@ class CopyTradeManager(QObject):
             self._update_history(record_id, "SUCCESS", slave_result_ticket)
             added_vol = response.get("volume", slave_lot)
             self._on_add_success(position_id, slave_key, added_vol, master_volume)
-            logger.info(f"    📊 ADD ok: +{added_vol} (slave: {existing_slave_vol} → {existing_slave_vol + added_vol})")
+            new_slave_vol = round(existing_slave_vol + added_vol, 8)
+            logger.info(f"    📊 ADD ok: +{added_vol} (slave: {existing_slave_vol} → {new_slave_vol})")
             self.copy_trade_executed.emit({"slave": slave_key, "symbol": symbol,
                                             "action": direction, "lot": slave_lot})
             return
@@ -1533,18 +1535,13 @@ class CopyTradeManager(QObject):
         self.db.commit()
 
     def request_trade_history(self, broker_key=None, limit=100):
-        """Solicita histórico de cópias. Fire-and-forget: a resposta chega
-        via signal `trade_history_ready` emitido na main thread.
-
-        Pode ser chamado de qualquer thread; o fetch acontece no motor.
-        """
+        """Fire-and-forget. Resposta via signal `trade_history_ready`."""
         if self.engine is None:
             logger.warning("request_trade_history: engine não wired — ignorado.")
             return
         self.engine.submit(self._fetch_trade_history(broker_key, limit))
 
     async def _fetch_trade_history(self, broker_key, limit):
-        """Roda no motor. Sem lock — engine asyncio é single-threaded."""
         try:
             if broker_key:
                 rows = self.db.execute(
@@ -1568,15 +1565,13 @@ class CopyTradeManager(QObject):
         self.trade_history_ready.emit(result, broker_key or "")
 
     def request_today_stats(self):
-        """Solicita estatísticas do dia. Fire-and-forget; resposta via
-        signal `today_stats_ready`."""
+        """Fire-and-forget. Resposta via signal `today_stats_ready`."""
         if self.engine is None:
             logger.warning("request_today_stats: engine não wired — ignorado.")
             return
         self.engine.submit(self._fetch_today_stats())
 
     async def _fetch_today_stats(self):
-        """Roda no motor."""
         today_start = datetime.datetime.now().replace(
             hour=0, minute=0, second=0, microsecond=0).timestamp()
         try:
@@ -1598,21 +1593,11 @@ class CopyTradeManager(QObject):
     # Bloco 6 - Shutdown
     # ──────────────────────────────────────────────
     def close(self):
-        """Fecha a conexão SQLite. Chamado pelo closeEvent do MainWindow.
-
-        Submete o close ao motor (DB nasceu lá e só ele deve tocar). Bloqueia
-        até o close terminar ou estourar timeout. Se engine não estiver
-        disponível (test environment), faz close direto.
-        """
+        """Fecha a conexão SQLite. No Windows, conexão aberta mantém o
+        arquivo locked. Submete ao motor (single-threaded asyncio) e
+        bloqueia até concluir ou estourar timeout."""
         if self.engine is None:
-            if self.db is not None:
-                try:
-                    self.db.close()
-                    logger.info("Conexão SQLite fechada (sem engine).")
-                except Exception as e:
-                    logger.warning(f"Erro ao fechar DB: {e}")
-                finally:
-                    self.db = None
+            self._do_close()
             return
         try:
             fut = self.engine.submit(self._async_close())
@@ -1621,13 +1606,15 @@ class CopyTradeManager(QObject):
             logger.warning(f"async_close timeout/erro: {e}")
 
     async def _async_close(self):
-        """Fecha conexão SQLite no motor. No Windows, conexão aberta mantém
-        o arquivo locked e impede backup/delete."""
-        if self.db is not None:
-            try:
-                self.db.close()
-                logger.info("Conexão SQLite fechada.")
-            except Exception as e:
-                logger.warning(f"Erro ao fechar DB: {e}")
-            finally:
-                self.db = None
+        self._do_close()
+
+    def _do_close(self):
+        if self.db is None:
+            return
+        try:
+            self.db.close()
+            logger.info("Conexão SQLite fechada.")
+        except Exception as e:
+            logger.warning(f"Erro ao fechar DB: {e}")
+        finally:
+            self.db = None

--- a/core/mt5_process_monitor.py
+++ b/core/mt5_process_monitor.py
@@ -5,7 +5,6 @@
 
 import os
 import subprocess
-import sys
 import time
 import logging
 import asyncio
@@ -169,9 +168,6 @@ class MT5ProcessMonitor:
                 si = subprocess.STARTUPINFO()
                 si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
                 si.wShowWindow = 6  # SW_MINIMIZE
-                # HIGH_PRIORITY_CLASS: mesmo motivo de connect_broker — o
-                # processo reiniciado pelo watchdog precisa da mesma proteção
-                # contra throttle do Windows quando perde foco.
                 process = subprocess.Popen(
                     [
                         instance_path,
@@ -199,8 +195,7 @@ class MT5ProcessMonitor:
             self.broker_manager.set_connected(key, True)
             logger.info(f"MT5 reiniciado para {key} (PID: {process.pid}).")
 
-            # EcoQoS opt-out (mesmo motivo de connect_broker).
-            if sys.platform.startswith("win") and disable_power_throttling(process.pid):
+            if disable_power_throttling(process.pid):
                 logger.debug(f"Power throttling desligado para {key} (pid={process.pid}).")
 
             if self.broker_manager.tcp_router and self.event_loop:

--- a/core/win_process.py
+++ b/core/win_process.py
@@ -1,12 +1,5 @@
-# EPCopyFlow 2.0
 # core/win_process.py
 # Helpers Windows-específicos via ctypes.
-#
-# disable_power_throttling: opt-out do EcoQoS / Power Throttling do Windows
-# para um processo. HIGH_PRIORITY_CLASS e EcoQoS são ortogonais — Windows
-# pode marcar processo em background como "Eco" mesmo com prioridade alta,
-# reduzindo CPU/IO. Isso afeta MT5 ao perder foco.
-# Doc: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-process_power_throttling_state
 
 import sys
 import logging
@@ -23,9 +16,14 @@ _PROCESS_POWER_THROTTLING_EXECUTION_SPEED = 0x1
 def disable_power_throttling(pid: int) -> bool:
     """Desliga EcoQoS / Power Throttling para o processo `pid`.
 
-    Retorna True em sucesso, False em qualquer falha (ambiente não-Windows,
-    API indisponível em versão antiga do Windows, processo já morto, sem
-    permissão, etc.). Nunca lança — falha silenciosa com log de warning.
+    HIGH_PRIORITY_CLASS e EcoQoS são ortogonais: Windows pode marcar processo
+    em background como "Eco" mesmo com prioridade alta. Esta chamada via
+    `SetProcessInformation` desliga o throttle de execution speed.
+
+    Retorna True em sucesso, False em qualquer falha (não-Windows, Windows
+    pré-1709, processo morto, sem permissão). Nunca lança.
+
+    Doc: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-process_power_throttling_state
     """
     if not sys.platform.startswith("win"):
         return False

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -265,7 +265,6 @@ class MainWindow(QMainWindow):
             self.copytrade_manager.copy_trade_log.connect(self.logs_page.append_log)
             self.copytrade_manager.copy_trade_executed.connect(self.history_page.refresh)
             self.copytrade_manager.copy_trade_failed.connect(self.history_page.refresh)
-            # Refresh dos stat cards do dashboard a cada trade replicado.
             self.copytrade_manager.copy_trade_executed.connect(self.dashboard_page.refresh_stats)
             self.copytrade_manager.copy_trade_failed.connect(self.dashboard_page.refresh_stats)
         # Alien trade detection
@@ -301,9 +300,8 @@ class MainWindow(QMainWindow):
     def _on_alien_trade_detected(self, data: dict):
         """Publica alerta não-modal no centro de notificações da barra superior.
 
-        Importante: NÃO usar QMessageBox.warning() aqui — ele cria um event
-        loop aninhado (exec()) que conflita com QtAsyncio e deixa o main
-        loop em estado inconsistente durante o tempo que o modal fica aberto.
+        NÃO usar QMessageBox.warning() aqui — cria event loop aninhado
+        (exec()) que deixa a janela inconsistente enquanto o modal fica aberto.
         """
         broker = data.get("broker_key", "?")
         symbol = data.get("symbol", "?")

--- a/gui/pages/dashboard_page.py
+++ b/gui/pages/dashboard_page.py
@@ -7,7 +7,7 @@ from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QScrollArea,
     QFrame, QGridLayout, QSizePolicy
 )
-from PySide6.QtCore import Slot, Qt
+from PySide6.QtCore import Slot, Qt, QTimer
 from gui.widgets.broker_card import BrokerCard
 from gui import themes
 
@@ -23,6 +23,9 @@ class DashboardPage(QWidget):
         self.tcp_message_handler = tcp_message_handler
         self._broker_status = {}  # EA registered: {key: True/False}
         self.broker_cards = {}
+        # Debounce de refresh_stats: coalesce bursts de copy_trade_executed em
+        # uma única query a cada 200ms.
+        self._stats_refresh_pending = False
         self.setStyleSheet(themes.dashboard_style())
         self._init_ui()
         if self.copytrade_manager is not None:
@@ -153,21 +156,24 @@ class DashboardPage(QWidget):
         self.update_broker_indicators()
 
     def _update_copytrade_stats(self):
-        """Pede stats ao motor. Resposta chega via _on_today_stats_ready."""
         if not self.copytrade_manager:
             return
         self.copytrade_manager.request_today_stats()
 
     @Slot(dict)
     def refresh_stats(self, _data=None):
-        """Slot público para refresh dos stat cards. Conectado a
-        copy_trade_executed/copy_trade_failed em main_window — atualiza
-        os cards a cada trade replicado."""
+        """Pede refresh dos stat cards. Coalesce bursts em 200ms."""
+        if self._stats_refresh_pending:
+            return
+        self._stats_refresh_pending = True
+        QTimer.singleShot(200, self._do_stats_refresh)
+
+    def _do_stats_refresh(self):
+        self._stats_refresh_pending = False
         self._update_copytrade_stats()
 
     @Slot(dict)
     def _on_today_stats_ready(self, stats):
-        """Slot do signal cross-thread. Roda na main thread."""
         self.stat_total._value_label.setText(str(stats.get("total", 0)))
         self.stat_success._value_label.setText(str(stats.get("success", 0)))
         self.stat_failed._value_label.setText(str(stats.get("failed", 0)))

--- a/gui/pages/history_page.py
+++ b/gui/pages/history_page.py
@@ -63,15 +63,12 @@ class HistoryPage(QWidget):
 
     @Slot()
     def refresh(self, _data=None):
-        """Pede o histórico ao motor. Resposta chega via signal
-        trade_history_ready → _on_history_ready."""
         if not self.copytrade_manager:
             return
         self.copytrade_manager.request_trade_history(limit=200)
 
     @Slot(list, str)
     def _on_history_ready(self, rows, broker_key_filter):
-        """Slot do signal cross-thread. Roda na main thread."""
         filter_text = self.filter_combo.currentText()
 
         filtered = []

--- a/gui/widgets/notification_center.py
+++ b/gui/widgets/notification_center.py
@@ -1,16 +1,9 @@
-# EPCopyFlow 2.0 - Versão 0.0.1 - Claude Code Parte 000
 # gui/widgets/notification_center.py
 # Centro de notificações global exibido no centro da barra superior.
-#
-# Substitui QMessageBox modais por um widget não-modal que:
-#   - Fica oculto quando não há notificações não-lidas
-#   - Aparece com ícone + contador colorido pela maior severidade
-#   - Pisca (WARNING/ERROR) e emite beep do sistema ao receber
-#   - Ao clicar, abre um popup não-modal com o histórico recente
-#   - Auto-dispensa INFO após 5s; WARNING/ERROR só saem por clique
-#
-# Essencial: este widget NÃO usa exec()/QMessageBox, portanto não cria
-# event loop aninhado — compatível com QtAsyncio.
+# Substitui QMessageBox modais por um widget não-modal: fica oculto quando
+# não há notificações, aparece com ícone+contador colorido pela maior
+# severidade, pisca em WARNING/ERROR, e abre popup com histórico ao clicar.
+# Auto-dispensa INFO após 5s; WARNING/ERROR só saem por clique.
 
 import logging
 from collections import deque


### PR DESCRIPTION
Aplicada após review automatizado (reuse / quality / efficiency) dos PRs 2.5, 2.6, B, 3 e do follow-up do dashboard. Sem mudança funcional visível ao usuário, exceto pelo debounce e índice (ambos performance).

**Performance:**

- Adicionado CREATE INDEX IF NOT EXISTS idx_copytrade_history_timestamp ON copytrade_history(timestamp) em _init_db. As queries _fetch_today_stats (WHERE timestamp >= ?) e _fetch_trade_history (ORDER BY timestamp DESC) faziam full scan; com a tabela crescendo ao longo do tempo, isso degradaria.

- Debounce de 200ms em dashboard_page.refresh_stats via QTimer.singleShot. Cada copy_trade_executed/copy_trade_failed dispara request_today_stats; em real-B3 com burst de trades isso geraria múltiplas queries por segundo (todas async, mas coalescer é mais barato e dá UI mais previsível).

**Reuse:**

- Removido sys.platform.startswith("win") redundante em 2 sites (connect_broker, restart_mt5_instance). disable_power_throttling já checa internamente. Também removido import sys órfão de mt5_process_monitor.py após o cleanup.

- Refatorado CopyTradeManager.close() / _async_close() para compartilhar helper _do_close() — eliminou duplicação do try/except/finally que existia em 2 caminhos (com e sem engine).

**Quality (comentários):**

Removidas referências meta a PR/issue ("PR 3, issue #111", "PR X troca por Y"), anedotas de log que vivem no CHANGELOG/git ("respostas de TRADE_POSITION_CLOSE_ID demorando 25s+"), e docstrings de Slot que narravam o óbvio ("Slot do signal cross-thread. Roda na main thread"). Mantido o "porquê" intemporal — invariantes não-óbvios, motivos arquiteturais que ainda valem.

Arquivos tocados:
  - core/copytrade_manager.py (signals/init/close/index/log noise)
  - core/broker_manager.py (HIGH_PRIORITY/EcoQoS comments)
  - core/mt5_process_monitor.py (drop sys, drop comments)
  - core/win_process.py (header trim, docstring absorvendo a info)
  - gui/main_window.py (drop comment)
  - gui/widgets/notification_center.py (header trim, drop QtAsyncio ref)
  - gui/pages/dashboard_page.py (debounce + drop comment)
  - gui/pages/history_page.py (drop slot comment)

**Cosmético:**

Linha de log "ADD ok: +0.05 (slave: 0.1 → 0.15000000000000002)" virou "slave: 0.1 → 0.15" via round(_, 8). Ruído de aritmética float que aparecia em todo ADD subsequente.

Validação:
- AST parse OK em todos os 9 arquivos.
- tests.test_engine_thread: 13/13 passando.