### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Tipos de mudança:
 
 ## [Unreleased]
 
+## [0.1.9] — 2026-05-02
+
 ### Fixed
 - **Dashboard não atualizava stat cards após trade replicado** (#111, follow-up PR 3): bug pré-existente exposto pelo smoke test do PR 3. `dashboard_page._update_copytrade_stats()` só era chamado em startup, theme change ou broker connect/disconnect — nunca em resposta a `copy_trade_executed`/`copy_trade_failed`. Histórico já tinha esse wire (linhas 266-267 de `main_window.py`); dashboard ficou de fora desde sempre. Adicionado `refresh_stats(_data=None)` como Slot público em `dashboard_page.py` e conectado os 2 sinais em `main_window.py`. Agora cada trade replicado dispara um refresh dos cards Total/Sucesso/Falha. Não tem custo extra — `request_today_stats` é fire-and-forget no motor.
 - **EcoQoS / Power Throttling do Windows não era desligado pelos processos MT5** (#111, PR 2.6): teste em conta REAL (B3) com 7 MT5s mostrou que `HIGH_PRIORITY_CLASS` do PR 2.5 não bastou — usuário relatou freeze ao alternar janelas e lentidão no painel "Negociação" do próprio MT5 (não na nossa GUI). Pesquisa confirmou: priority class e EcoQoS são ortogonais na Microsoft API. Mesmo com prioridade alta, Windows pode marcar processo em background como "Eco" e reduzir CPU/IO — efeito agravado em real (mais ticks, mais book) versus demo (sintético). Adicionado `core/win_process.py` com helper `disable_power_throttling(pid)` que chama `SetProcessInformation` via `ctypes` com `ProcessPowerThrottling` + `PROCESS_POWER_THROTTLING_EXECUTION_SPEED`, `StateMask=0` (desligado). Wired após `subprocess.Popen` em `core/broker_manager.py::connect_broker` e `core/mt5_process_monitor.py::restart_mt5_instance`. Falha silenciosa com log de warning se a API estiver indisponível (Windows < 1709) ou OpenProcess falhar — não derruba o app. Não-Windows: no-op. Doc Microsoft: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-process_power_throttling_state
@@ -25,6 +27,9 @@ Tipos de mudança:
 - **Dívida técnica registrada (não corrigida neste PR)**: como o Python loga falha por timeout enquanto o broker pode confirmar a operação tardiamente (ex.: trade do XP foi executado com `retcode: 10009` mas o registro local já tinha sido marcado como falha), o DB do copytrade pode ficar inconsistente com a realidade do broker em cenários de throttle severo. Natureza similar (mas independente) do que motivou #56. Tratamento adequado fica para issue futura — depende de medirmos se o `HIGH_PRIORITY_CLASS` por si só já elimina o cenário em produção real.
 
 ### Changed
+- **Logs reduzidos em `copytrade_manager.py`**: pente fino tirando 14 logs `DEBUG` redundantes (eventos descartados, dedup, prints internos de `_track_master_position` e `_on_*_success`) e 13 `INFO` que duplicavam informação já presente no log canônico do mesmo fluxo (recebimento, classificação, dump completo de respostas em `_replicate_close`/`_send_*_command` e nas duas etapas do REVERSAL). Total: 114 → 88 logs. `copy_trade_log.emit(...)` (alimenta a `LogsPage` da GUI) e todos `warning`/`error`/`exception` preservados.
+- **`config.ini`**: `log_level` agora `INFO` por padrão (era `DEBUG`); `monitor_interval` baixado de `1s` para `5s` — o watchdog do MT5 conferia processo a cada segundo, exagero para detecção de crash; 5s mantém o objetivo com 5× menos overhead.
+- **`MainWindow.version_label`**: passa a usar `core.version.__version__` em vez do `"v0.0.1"` hardcoded, que estava desatualizado desde a 0.1.0.
 - **Limpeza geral de código pós-refactor** (#111, follow-up): aplicada após
   review automatizado dos PRs 2.5/2.6/B/3. Mudanças:
   - **Índice em `copytrade_history(timestamp)`** (`_init_db`): `_fetch_today_stats`
@@ -192,7 +197,8 @@ Tipos de mudança:
 - Monitor de processo MT5 (detecta crash e reinicia)
 - Monitor de internet (detecta queda de conexão)
 
-[Unreleased]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.9...HEAD
+[0.1.9]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/EPFILHO/EPCopyFlow2.0/compare/v0.1.5...v0.1.6

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,6 @@
 [General]
 ; Nível de log (DEBUG, INFO, WARNING, ERROR)
-log_level = DEBUG
+log_level = INFO
 ; Tempo da splash em segundos
 splash_duration = 2
 ; Mostrar splash ao iniciar
@@ -14,7 +14,7 @@ debounce_interval = 3
 ; Pausa inicial do monitoramento (segundos)
 monitor_initial_delay = 2
 ; Intervalo de verificação do monitor de processos MT5 (segundos)
-monitor_interval = 1
+monitor_interval = 5
 ; Caminho do diretório raiz do MT5 instalado
 base_mt5_path = C:\Temp\MT5
 ; Caminho do arquivo de cadastro de corretoras

--- a/core/copytrade_manager.py
+++ b/core/copytrade_manager.py
@@ -192,7 +192,6 @@ class CopyTradeManager(QObject):
         """
         try:
             request_id = f"get_account_mode_{broker_key}_{int(time.time())}"
-            logger.debug(f"🔍 Detectando account mode de {broker_key}...")
 
             response = await self.tcp_router.send_command_to_broker(
                 broker_key, "GET_ACCOUNT_MODE", {}, request_id
@@ -441,8 +440,6 @@ class CopyTradeManager(QObject):
         request_data = trade_event.get("request", {})
         result_data = trade_event.get("result", {})
 
-        logger.info(f"🔍 handle_master_trade_event recebido de {master_broker}")
-
         # Suprimir replicação durante emergency close (evita double close)
         if self._emergency_active:
             logger.warning(f"  Replicação suprimida: emergency close ativo")
@@ -461,13 +458,11 @@ class CopyTradeManager(QObject):
         # Verifica se é realmente do master
         broker_role = self.broker_manager.get_broker_role(master_broker)
         if broker_role != "master":
-            logger.debug(f"Trade event ignorado: {master_broker} não é master.")
             return
 
         # Filtrar ações não replicáveis antes de extrair tudo (reduz barulho no log)
         action = request_data.get("action", 0)
         if action != 1:  # Só TRADE_ACTION_DEAL (1) é replicável
-            logger.debug(f"Trade event ignorado: action={action} (não é DEAL)")
             return
 
         # Extrair informações do trade
@@ -484,9 +479,6 @@ class CopyTradeManager(QObject):
 
         # POSITION_IDENTIFIER — chave universal (vem do EA)
         position_id = trade_event.get("position_id", 0)
-
-        logger.info(f"  action={action}, symbol={symbol}, volume={volume}, retcode={retcode}, "
-                     f"position_id={position_id}, deal={deal_ticket}, vol_remaining={position_volume_remaining}")
 
         # Só replica trades com sucesso (retcode 10009 = TRADE_RETCODE_DONE)
         if retcode != 10009 and retcode != 0:
@@ -512,9 +504,7 @@ class CopyTradeManager(QObject):
         else:
             # Determinar tipo de ação para replicação
             trade_action = self._classify_trade_action(action, order_type, position_ticket, position_volume_remaining)
-            logger.info(f"  trade_action={trade_action}")
             if not trade_action:
-                logger.debug(f"Ação de trade não replicável: action={action}, type={order_type}")
                 return
 
         # Validar que temos position_id (obrigatório para tracking)
@@ -529,7 +519,6 @@ class CopyTradeManager(QObject):
         dedup_key = (position_id, timestamp_mql, order_type)
         now = time.time()
         if dedup_key in self._master_event_dedup:
-            logger.debug(f"  Evento duplicado ignorado: pos_id={position_id}, ts_mql={timestamp_mql}, action={trade_action}")
             return
         self._master_event_dedup[dedup_key] = now
         # No reversal sintético, o OnTradeTransaction subsequente chega com o volume
@@ -570,7 +559,6 @@ class CopyTradeManager(QObject):
 
             # Replica para cada slave conectado (em paralelo entre slaves)
             slaves = self.broker_manager.get_connected_slave_brokers()
-            logger.info(f"  Slaves conectados: {slaves}")
             tasks = []
             for slave_key in slaves:
                 if self.is_slave_paused(slave_key):
@@ -697,7 +685,6 @@ class CopyTradeManager(QObject):
                         "WHERE position_id = ? AND master_broker = ? AND status = 'OPEN'",
                         (volume, sl, tp, position_id, master_broker)
                     )
-                    logger.debug(f"  📝 master_positions ADD: pos_id={position_id}, +{volume}")
                 else:
                     self.db.execute(
                         """INSERT INTO master_positions
@@ -706,7 +693,6 @@ class CopyTradeManager(QObject):
                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'OPEN', ?)""",
                         (master_broker, position_id, symbol, direction, volume, volume, sl, tp, now)
                     )
-                    logger.debug(f"  📝 master_positions OPEN: pos_id={position_id}, {direction} {volume}")
 
             elif trade_action == "REVERSAL":
                 self.db.execute(
@@ -714,7 +700,6 @@ class CopyTradeManager(QObject):
                     "WHERE position_id = ? AND master_broker = ? AND status = 'OPEN'",
                     (direction, volume, sl, tp, position_id, master_broker)
                 )
-                logger.debug(f"  📝 master_positions REVERSAL: pos_id={position_id}, {direction} {volume}")
 
             elif trade_action == "PARTIAL_CLOSE":
                 self.db.execute(
@@ -728,7 +713,6 @@ class CopyTradeManager(QObject):
                     "WHERE master_ticket = ? AND status = 'OPEN'",
                     (volume, position_id)
                 )
-                logger.debug(f"  📝 master_positions PARTIAL_CLOSE: pos_id={position_id}, vol_fechado={volume}")
 
             elif trade_action == "CLOSE":
                 self.db.execute(
@@ -740,7 +724,6 @@ class CopyTradeManager(QObject):
                     "UPDATE open_positions SET status = 'CLOSING' WHERE master_ticket = ? AND status = 'OPEN'",
                     (position_id,)
                 )
-                logger.debug(f"  📝 master_positions CLOSED: pos_id={position_id}")
 
     def _get_slave_position_info(self, position_id: int, slave_key: str) -> dict:
         """Retorna info da posição do slave: {volume, direction, master_volume}. None se não encontrado."""
@@ -810,8 +793,6 @@ class CopyTradeManager(QObject):
           - TRADE_ORDER_TYPE_SELL → abre/adiciona short ou reduz long
           - TRADE_POSITION_CLOSE_ID → fecha posição inteira por ticket
         """
-        logger.info(f"  ➜ _replicate_to_slave: slave={slave_key}, action={trade_action}, symbol={symbol}, pos_id={position_id}")
-
         symbol_specs = await self._fetch_symbol_specs(slave_key, symbol)
         multiplier = self.broker_manager.get_lot_multiplier(slave_key)
 
@@ -971,7 +952,6 @@ class CopyTradeManager(QObject):
         response = await self.tcp_router.send_command_to_broker(
             slave_key, "TRADE_POSITION_CLOSE_ID", {"ticket": slave_ticket}, request_id
         )
-        logger.info(f"    Resposta: {response}")
 
         if response.get("status") == "OK":
             slave_result_ticket = response.get("order", 0) or response.get("deal", 0)
@@ -1031,7 +1011,6 @@ class CopyTradeManager(QObject):
         response = await self.tcp_router.send_command_to_broker(
             slave_key, command, payload, request_id
         )
-        logger.info(f"    Resposta: {response}")
 
         if response.get("status") == "OK":
             slave_result_ticket = response.get("order", 0) or response.get("deal", 0)
@@ -1068,7 +1047,6 @@ class CopyTradeManager(QObject):
         response = await self.tcp_router.send_command_to_broker(
             slave_key, command, payload, request_id
         )
-        logger.info(f"    Resposta: {response}")
 
         if response.get("status") == "OK":
             slave_result_ticket = response.get("order", 0) or response.get("deal", 0)
@@ -1102,7 +1080,6 @@ class CopyTradeManager(QObject):
         response = await self.tcp_router.send_command_to_broker(
             slave_key, command, payload, request_id
         )
-        logger.info(f"    Resposta: {response}")
 
         if response.get("status") == "OK":
             slave_result_ticket = response.get("order", 0) or response.get("deal", 0)
@@ -1149,7 +1126,6 @@ class CopyTradeManager(QObject):
         close_response = await self.tcp_router.send_command_to_broker(
             slave_key, "TRADE_POSITION_CLOSE_ID", {"ticket": slave_ticket}, close_request_id
         )
-        logger.info(f"    REVERSAL etapa 1 (close) resposta: {close_response}")
 
         if close_response.get("status") != "OK":
             error = close_response.get("error_message", "") or close_response.get("message", "?")
@@ -1180,12 +1156,11 @@ class CopyTradeManager(QObject):
         payload = {"symbol": symbol, "volume": float(reverse_lot),
                    "price": 0.0, "sl": sl, "tp": tp,
                    "deviation": 10, "comment": f"CT:{position_id}"}
-        logger.info(f"    REVERSAL etapa 2: {command} {reverse_lot} → {command}")
+        logger.info(f"    REVERSAL etapa 2: {command} {reverse_lot}")
 
         open_response = await self.tcp_router.send_command_to_broker(
             slave_key, command, payload, open_request_id
         )
-        logger.info(f"    REVERSAL etapa 2 (open) resposta: {open_response}")
 
         if open_response.get("status") == "OK":
             new_slave_ticket = open_response.get("order", 0) or open_response.get("deal", 0)
@@ -1216,7 +1191,6 @@ class CopyTradeManager(QObject):
         se a posição realmente não existe mais (SL/TP/SO do broker fechou antes).
         Retorna True se resolvido (posição confirmada fechada), False se é erro real.
         """
-        logger.info(f"    Verificando se {symbol} ainda existe em {slave_key} via GET_POSITIONS...")
         req_id = f"verify_{slave_key}_{position_id}_{int(time.time())}"
         pos_response = await self.tcp_router.send_command_to_broker(
             slave_key, "GET_POSITIONS", {}, req_id
@@ -1277,7 +1251,6 @@ class CopyTradeManager(QObject):
              direction, request_id, now, now)
         )
         self.db.commit()
-        logger.debug(f"  ✅ Posição aberta: pos_id={position_id}, slave={slave_key}, slave_ticket={slave_ticket}, slave_lot={slave_lot}, dir={direction}")
 
     def _on_close_success(self, position_id: int, slave_key: str, close_reason: str = "COPYTRADE"):
         """Fechamento total confirmado — marcar CLOSED, limpar position_map."""
@@ -1291,7 +1264,6 @@ class CopyTradeManager(QObject):
             self.position_map[position_id].pop(slave_key, None)
             if not self.position_map[position_id]:
                 del self.position_map[position_id]
-        logger.debug(f"  ✅ Posição FECHADA: pos_id={position_id}, slave={slave_key}, reason={close_reason}")
 
     def _on_add_success(self, position_id: int, slave_key: str, added_volume: float, master_volume: float):
         """ADD à posição confirmado — incrementar volumes no DB."""
@@ -1305,7 +1277,6 @@ class CopyTradeManager(QObject):
             (added_volume, master_volume, now, position_id, slave_key)
         )
         self.db.commit()
-        logger.debug(f"  ✅ ADD ok: pos_id={position_id}, slave={slave_key}, +{added_volume} lotes")
 
     def _on_partial_close_success(self, position_id: int, slave_key: str, closed_volume: float):
         """Fechamento parcial confirmado — decrementar volume do slave."""
@@ -1317,7 +1288,6 @@ class CopyTradeManager(QObject):
             (closed_volume, now, position_id, slave_key)
         )
         self.db.commit()
-        logger.debug(f"  ✅ Parcial ok: pos_id={position_id}, slave={slave_key}, vol_fechado={closed_volume}")
 
     # ──────────────────────────────────────────────
     # Bloco 4 - Fechamento de Emergência

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
 #   MINOR: features novas (backward-compatible)
 #   PATCH: bugfixes (backward-compatible)
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -14,6 +14,7 @@ from core.config_manager import ConfigManager
 from core.broker_manager import BrokerManager
 from core.tcp_router import TcpRouter
 from core.tcp_message_handler import TcpMessageHandler
+from core.version import __version__
 from internet_monitor import InternetMonitor
 from gui import themes
 
@@ -214,7 +215,7 @@ class MainWindow(QMainWindow):
         layout.addStretch()
 
         # Version label at bottom
-        self.version_label = QLabel("v0.0.1")
+        self.version_label = QLabel(f"v{__version__}")
         self.version_label.setStyleSheet(themes.version_label_style())
         layout.addWidget(self.version_label)
 


### PR DESCRIPTION
Reduce log noise and tighten polling defaults — first round of the "rethink architecture" cleanup. No behavior change in the trade replication or persistence; only verbosity, defaults, and a hardcoded version label.

- copytrade_manager.py: 114 → 88 log statements
  - Drop all 14 logger.debug (impl-internal noise: dedup hits, trade-event discards, _track_master_position prints, _on_*_success markers)
  - Drop 13 logger.info redundant with the canonical log of the same flow (handle_master_trade_event header, action= field dump, trade_action=, "Slaves conectados", _replicate_to_slave header, "Resposta: response" in CLOSE/REDUCE/OPEN/ADD, REVERSAL etapa N "resposta", "Verificando…")
  - copy_trade_log.emit (GUI audience) and every warn/error/exception kept
- config.ini: log_level DEBUG → INFO (production-sane default); monitor_interval 1 → 5 (5× less process.poll overhead, crash detection still adequate)
- main_window: version_label reads core.version.__version__ instead of the stale hardcoded "v0.0.1" (wrong since 0.1.0)
- Move [Unreleased] block to [0.1.9] in CHANGELOG; add new entries on top of ### Changed

https://claude.ai/code/session_01CY2tx62Qf3xS5vxVrgpEAf